### PR TITLE
General Plugin API changes / Fixes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,18 +19,17 @@ repositories {
 }
 
 dependencies {
-    implementation("net.minestom:minestom-snapshots:1_21-9219e96f76")
-    implementation("com.google.code.gson:gson:2.11.0") // serializing
+    api("net.minestom:minestom-snapshots:1_21-9219e96f76")
+    api("com.google.code.gson:gson:2.11.0") // serializing
     implementation("org.slf4j:slf4j-api:2.0.13") // logging
     implementation("net.kyori:adventure-text-minimessage:4.17.0")// better components
     implementation("com.mysql:mysql-connector-j:8.4.0") //mysql connector
     compileOnly("org.projectlombok:lombok:1.18.32") // lombok
     annotationProcessor("org.projectlombok:lombok:1.18.32") // lombok
     implementation("org.tomlj:tomlj:1.1.1") // Config lang
-    implementation("com.rabbitmq:amqp-client:5.21.0") // Message broker
-    implementation("dev.hollowcube:polar:1.10.0") // Polar
-    implementation("com.google.guava:guava:33.2.1-jre") // a lot of things, but mostly caching
-    implementation("redis.clients:jedis:5.1.3") // redis client
+    api("com.rabbitmq:amqp-client:5.21.0") // Message broker
+    api("dev.hollowcube:polar:1.10.0") // Polar
+    api("redis.clients:jedis:5.1.3") // redis client
     implementation("org.reflections:reflections:0.10.2") // reflection utils
 }
 

--- a/src/main/java/net/cytonic/cytosis/data/DatabaseTemplate.java
+++ b/src/main/java/net/cytonic/cytosis/data/DatabaseTemplate.java
@@ -1,0 +1,18 @@
+package net.cytonic.cytosis.data;
+
+import net.cytonic.cytosis.Cytosis;
+
+import java.sql.ResultSet;
+import java.util.concurrent.CompletableFuture;
+
+public final class DatabaseTemplate {
+    private DatabaseTemplate() {
+    }
+
+    @SuppressWarnings("preview")
+    public static final StringTemplate.Processor<CompletableFuture<ResultSet>, RuntimeException> QUERY = stringTemplate -> Cytosis.getDatabaseManager().getMysqlDatabase().query(STR.process(stringTemplate));
+
+    @SuppressWarnings("preview")
+    public static final StringTemplate.Processor<CompletableFuture<Void>, RuntimeException> UPDATE = stringTemplate -> Cytosis.getDatabaseManager().getMysqlDatabase().update(STR.process(stringTemplate));
+
+}

--- a/src/main/java/net/cytonic/cytosis/data/MysqlDatabase.java
+++ b/src/main/java/net/cytonic/cytosis/data/MysqlDatabase.java
@@ -15,6 +15,7 @@ import net.minestom.server.MinecraftServer;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.entity.Player;
 import org.jetbrains.annotations.NotNull;
+
 import java.net.SocketAddress;
 import java.sql.*;
 import java.time.Instant;
@@ -548,5 +549,43 @@ public class MysqlDatabase {
                 Logger.error("Failed to add a player to the database!", e);
             }
         });
+    }
+
+    /**
+     * Queries the database with the specified SQL
+     *
+     * @param sql The SQL query
+     * @return The {@link ResultSet} of the query
+     */
+    CompletableFuture<ResultSet> query(String sql) {
+        CompletableFuture<ResultSet> future = new CompletableFuture<>();
+        worker.submit(() -> {
+            try (PreparedStatement ps = connection.prepareStatement(sql)) {
+                ResultSet rs = ps.executeQuery();
+                future.complete(rs);
+            } catch (SQLException e) {
+                future.completeExceptionally(e);
+            }
+        });
+        return future;
+    }
+
+    /**
+     * Updates the database with the specified SQL
+     *
+     * @param sql The SQL update
+     * @return A {@link CompletableFuture} for when the update is completed
+     */
+    CompletableFuture<Void> update(String sql) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        worker.submit(() -> {
+            try (PreparedStatement ps = connection.prepareStatement(sql)) {
+                ps.executeUpdate();
+                future.complete(null);
+            } catch (SQLException e) {
+                future.completeExceptionally(e);
+            }
+        });
+        return future;
     }
 }

--- a/src/main/java/net/cytonic/cytosis/messaging/RabbitMQ.java
+++ b/src/main/java/net/cytonic/cytosis/messaging/RabbitMQ.java
@@ -236,6 +236,20 @@ public class RabbitMQ {
     }
 
     /**
+     * Registers an exchange with RabbitMQ
+     *
+     * @param exchange The name of the exchange
+     * @param type     The type of the exchange
+     */
+    public void registerExchange(String exchange, String type) {
+        try {
+            channel.exchangeDeclare(exchange, type);
+        } catch (IOException e) {
+            Logger.error(STR."An error occurred whilst attempting to register the exchange '\{exchange}'", e);
+        }
+    }
+
+    /**
      * Binds a queue to an exchange
      *
      * @param queue      The queue to bind

--- a/src/main/java/net/cytonic/cytosis/messaging/RabbitMQ.java
+++ b/src/main/java/net/cytonic/cytosis/messaging/RabbitMQ.java
@@ -221,11 +221,32 @@ public class RabbitMQ {
     /*
      * RabbitMQ via the Plugins API
      */
+
+    /**
+     * Registers a queue with RabbitMQ
+     *
+     * @param queue the queue to register
+     */
     public void registerQueue(String queue) {
         try {
             channel.queueDeclare(queue, false, false, false, null);
         } catch (IOException e) {
             Logger.error(STR."An error occurred whilst attempting to register the queue '\{queue}'", e);
+        }
+    }
+
+    /**
+     * Binds a queue to an exchange
+     *
+     * @param queue      The queue to bind
+     * @param exchange   The exchange to bind the queue to
+     * @param routingKey The routing key
+     */
+    public void bindQueue(String queue, String exchange, String routingKey) {
+        try {
+            channel.queueBind(queue, exchange, routingKey);
+        } catch (IOException e) {
+            Logger.error(STR."An error occurred whilst attempting to bind the queue '\{queue}'", e);
         }
     }
 

--- a/src/main/java/net/cytonic/cytosis/utils/Utils.java
+++ b/src/main/java/net/cytonic/cytosis/utils/Utils.java
@@ -1,5 +1,9 @@
 package net.cytonic.cytosis.utils;
 
+import net.cytonic.cytosis.logging.Logger;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,5 +21,16 @@ public class Utils {
     @SafeVarargs
     public static <E> List<E> list(E... vararg) {
         return new ArrayList<>(List.of(vararg));
+    }
+
+    public static String getServerIP() {
+        String serverIP;
+        try {
+            serverIP = InetAddress.getLocalHost().getHostAddress();
+        } catch (UnknownHostException e) {
+            Logger.error("An error occurred whilst fetching this server's IP address! Bailing out!", e);
+            return "ERROR";
+        }
+        return serverIP;
     }
 }


### PR DESCRIPTION
Closes #73
Closes #93
Closes #94

Changes:
- Make some dependencies `api` instead of `implementation`
- Remove Guava as we dont use it and its bloat
- Create methods in the RabbitMQ class to use it from a plugin
- Create methods in the Database class to use it from a plugin
- Create a StringTemplate for querying the database:
    - Example syntax: `QUERY."SELECT * FROM table_name WHERE uuid=\{uuid}"`
    - It returns a ResultSet object with the query data
    - Another example: `UPDATE."INSERT INTO table_name (time, uuid, name) VALUES (CURRENT_TIMESTAMP,\{uuid},\{name})"`
    - It just returns an empty future so a consumer can run after completion
- Created a Util method in Utils to get the server IP