### PR TITLE
General NPC api fixes and QOL

### DIFF
--- a/src/main/java/net/cytonic/cytosis/npcs/Humanoid.java
+++ b/src/main/java/net/cytonic/cytosis/npcs/Humanoid.java
@@ -5,6 +5,7 @@ import net.cytonic.cytosis.utils.Utils;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.minestom.server.coordinate.Pos;
+import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.*;
 import net.minestom.server.entity.metadata.PlayerMeta;
 import net.minestom.server.entity.metadata.display.AbstractDisplayMeta;
@@ -33,6 +34,7 @@ public class Humanoid extends EntityCreature implements NPC {
     private PlayerSkin skin;
     private boolean glowing = false;
     private NamedTextColor glowingColor = NamedTextColor.WHITE;
+    private boolean damagable = false;
 
     /**
      * Creates a new Humanoid from uuid, username, and skin
@@ -71,7 +73,7 @@ public class Humanoid extends EntityCreature implements NPC {
         super.updateNewViewer(player);
         player.sendPackets(new EntityMetaDataPacket(getEntityId(), Map.of(17, Metadata.Byte((byte) 127))));
 
-        var team = new TeamsPacket("NPC-" + getUuid().toString() + "",
+        var team = new TeamsPacket("NPC-" + getUuid(),
                 new TeamsPacket.CreateTeamAction(Component.empty(),
                         (byte) 0x0, TeamsPacket.NameTagVisibility.NEVER,
                         TeamsPacket.CollisionRule.NEVER, glowingColor,
@@ -140,20 +142,22 @@ public class Humanoid extends EntityCreature implements NPC {
 
     @Override
     public void createHolograms() {
+
         final double spacing = 0.3;
         for (int i = 0; i < lines.size(); i++) {
             Entity hologram = new Entity(EntityType.TEXT_DISPLAY);
             int finalI = i;
+            Pos pos = position.add(0, ((i + 1) * spacing), 0);
             hologram.editEntityMeta(TextDisplayMeta.class, meta -> {
                 meta.setText(lines.get(finalI));
                 meta.setBillboardRenderConstraints(AbstractDisplayMeta.BillboardConstraints.CENTER);
                 meta.setHasNoGravity(true);
+                meta.setTranslation(new Vec(0, ((finalI + 1) * spacing), 0));
             });
 
-            Pos pos = position.add(0, (i * spacing) + 2.05, 0);
 
             hologram.setInstance(instance, pos);
-            hologram.teleport(pos);
+            addPassenger(hologram);
         }
     }
 }

--- a/src/main/java/net/cytonic/cytosis/npcs/HumanoidBuilder.java
+++ b/src/main/java/net/cytonic/cytosis/npcs/HumanoidBuilder.java
@@ -6,6 +6,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.entity.PlayerSkin;
 import net.minestom.server.instance.Instance;
+import net.minestom.server.tag.Tag;
 
 import java.util.UUID;
 
@@ -56,7 +57,58 @@ public class HumanoidBuilder {
      * @return The builder with updated data
      */
     public HumanoidBuilder skin(String value, String signature) {
-        this.skin(new PlayerSkin(value, signature));
+        return this.skin(new PlayerSkin(value, signature));
+    }
+
+    /**
+     * Sets the skin to a random default skin like steve or alex
+     *
+     * @return the builder for chaining
+     */
+    public HumanoidBuilder defaultSkin() {
+        return this.skin(new PlayerSkin(null, null));
+    }
+
+    /**
+     * Makes this NPC either able to be damaged or unable to be damaged
+     *
+     * @param invulnerable if this npc should be immune to damage
+     * @return the builder, for chaining
+     */
+    public HumanoidBuilder invulnerable(boolean invulnerable) {
+        NPC.setInvulnerable(invulnerable);
+        return this;
+    }
+
+    /**
+     * Makes this NPC invulnerable, or unable to be damaged
+     *
+     * @return the builder, for chaining
+     */
+    public HumanoidBuilder invulnerable() {
+        return this.invulnerable(true);
+    }
+
+    /**
+     * Tags this NPC with the given string value. Repeating this tag overwrites any previously written data
+     *
+     * @param tag The string data to associate with the NPC
+     * @return The builder, for chaining
+     */
+    public HumanoidBuilder tag(String tag) {
+        return tag(net.cytonic.cytosis.npcs.NPC.DATA_TAG, tag);
+    }
+
+    /**
+     * Tags the NPC with the given Tag and corresponding value. Calling this method multiple times for the same tag, overwrites existing data.
+     *
+     * @param tag   The tag to tag the NPC with
+     * @param value the value to associate with the tag
+     * @param <T>   The type of the tag.
+     * @return the builder, for chaining.
+     */
+    public <T> HumanoidBuilder tag(Tag<T> tag, T value) {
+        NPC.setTag(tag, value);
         return this;
     }
 

--- a/src/main/java/net/cytonic/cytosis/npcs/NPC.java
+++ b/src/main/java/net/cytonic/cytosis/npcs/NPC.java
@@ -4,6 +4,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.instance.Instance;
+import net.minestom.server.tag.Tag;
 
 import java.util.List;
 import java.util.UUID;
@@ -12,6 +13,8 @@ import java.util.UUID;
  * The blueprint for an NPC
  */
 public interface NPC {
+
+    Tag<String> DATA_TAG = Tag.String("npc_data");
 
     /**
      * Creates a Humanoid NPC builder


### PR DESCRIPTION
Fixes #367 

This pr adds a tagging system to the NPCs, which relies on the Minestom Tag API.
It also adds invulnerability to the Humanoid builder, which prevents npcs from being damaged.
The holograms are considered passengers, and now move with the npc as it does.