### PR TITLE
Feature: Runtime Dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ bin/
 .DS_Store
 
 build-number.txt
+# runtime dependencies
+/cache/
+/config.toml

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     id("java")
     id("com.github.johnrengelman.shadow") version "8.1.1"
     id("com.github.harbby.gradle.serviceloader") version ("1.1.9")
+    id("dev.vankka.dependencydownload.plugin") version "1.3.1"
 }
 
 group = "net.cytonic"
@@ -19,46 +20,61 @@ repositories {
 }
 
 dependencies {
-    api("net.minestom:minestom-snapshots:0366b58bfe")
-    api("com.google.code.gson:gson:2.12.1") // serializing
-    api("com.squareup.okhttp3:okhttp:4.12.0") // http api requests
-    implementation("net.kyori:adventure-text-minimessage:4.19.0")// better components
-    implementation("com.mysql:mysql-connector-j:9.2.0") //mysql connector
+    compileOnlyApi("net.minestom:minestom-snapshots:0366b58bfe")
+    compileOnlyApi("com.google.code.gson:gson:2.12.1") // serializing
+    compileOnlyApi("com.squareup.okhttp3:okhttp:4.12.0") // http api requests
+    compileOnlyApi("dev.hollowcube:polar:1.13.0") // Polar
+    compileOnlyApi("redis.clients:jedis:5.2.0") // redis client
+    compileOnlyApi("com.google.guava:guava:33.4.5-jre")
+
     compileOnly("org.projectlombok:lombok:1.18.36") // lombok
     annotationProcessor("org.projectlombok:lombok:1.18.36") // lombok
-    implementation("org.tomlj:tomlj:1.1.1") // Config lang
-    api("dev.hollowcube:polar:1.13.0") // Polar
-    api("redis.clients:jedis:5.2.0") // redis client
-    api("com.google.guava:guava:33.4.5-jre")
-    implementation("org.reflections:reflections:0.10.2") // reflection utils
-    implementation("org.slf4j:slf4j-api:2.0.17")  // SLF4J API
-    implementation("org.apache.logging.log4j:log4j-core:2.24.3")  // Log4j core
-    implementation("org.apache.logging.log4j:log4j-slf4j2-impl:2.24.3")
-    implementation("io.nats:jnats:2.20.6")
-    implementation("org.jooq:jooq:3.20.2") // database queries
-    implementation("com.github.TogAr2:MinestomPvP:1b2f862baa") // pvp
-    implementation("eu.koboo:minestom-invue:2025.1.1") {
+
+    runtimeDownload("net.kyori:adventure-text-minimessage:4.19.0")// better components
+    runtimeDownload("com.mysql:mysql-connector-j:9.2.0") //mysql connector
+    runtimeDownload("org.tomlj:tomlj:1.1.1") // Config lang
+    runtimeDownload("org.reflections:reflections:0.10.2") // reflection utils
+    runtimeDownload("org.slf4j:slf4j-api:2.0.17")  // SLF4J API
+    runtimeDownload("org.apache.logging.log4j:log4j-core:2.24.3")  // Log4j core
+    runtimeDownload("org.apache.logging.log4j:log4j-slf4j2-impl:2.24.3")
+    runtimeDownload("io.nats:jnats:2.20.6")
+    runtimeDownload("org.jooq:jooq:3.20.2") // database queries
+    runtimeDownload("com.github.TogAr2:MinestomPvP:1b2f862baa") // pvp
+    runtimeDownload("io.opentelemetry:opentelemetry-api:1.48.0")
+    runtimeDownload("io.opentelemetry:opentelemetry-sdk:1.48.0")
+    runtimeDownload("io.opentelemetry:opentelemetry-exporter-otlp:1.48.0")
+    runtimeDownload("eu.koboo:minestom-invue:2025.1.1") {
         // we want to use our own, thank you :)
         exclude(group = "net.minestom", module = "minestom-snapshots")
     }
 
+    // the compileonlyapis need to be downloaded at runtime, too.
+    runtimeDownloadOnly("net.minestom:minestom-snapshots:0366b58bfe")
+    runtimeDownloadOnly("com.google.code.gson:gson:2.12.1")
+    runtimeDownloadOnly("com.squareup.okhttp3:okhttp:4.12.0")
+    runtimeDownloadOnly("dev.hollowcube:polar:1.13.0")
+    runtimeDownloadOnly("redis.clients:jedis:5.2.0")
+    runtimeDownloadOnly("com.google.guava:guava:33.4.5-jre")
 
-    // Core OpenTelemetry API & SDK
-    implementation("io.opentelemetry:opentelemetry-api:1.48.0")
-    implementation("io.opentelemetry:opentelemetry-sdk:1.48.0")
-    // OTLP Exporter (to send data to a collector/backend)
-    implementation("io.opentelemetry:opentelemetry-exporter-otlp:1.48.0")
+    // Dependency loading
+    implementation("dev.vankka:dependencydownload-runtime:1.3.1")
 }
 
 tasks.withType<Jar> {
+    dependsOn(
+        "generateRuntimeDownloadResourceForRuntimeDownloadOnly",
+        "generateRuntimeDownloadResourceForRuntimeDownload"
+    )
     manifest {
-        attributes["Main-Class"] = "net.cytonic.cytosis.Cytosis"
+        attributes["Main-Class"] = "net.cytonic.cytosis.bootstrap.Bootstrapper"
     }
 }
 tasks.withType<Javadoc> {
     val javadocOptions = options as CoreJavadocOptions
     javadocOptions.addStringOption("source", "21")
 }
+
+var bundled = false
 
 val generateBuildInfo = tasks.register("generateBuildInfo") {
     dependsOn("incrementBuildNumber")
@@ -80,6 +96,7 @@ val generateBuildInfo = tasks.register("generateBuildInfo") {
                 public static final String BUILD_NUMBER = "$buildNumber";
                 public static final String GIT_COMMIT = "${"git rev-parse --short HEAD".runCommand()}";
                 public static final java.time.Instant BUILT_AT = java.time.Instant.ofEpochMilli(${System.currentTimeMillis()}L);
+                public static final boolean DEPENDENCIES_BUNDLED=${bundled};
             }
             """.trimIndent()
         )
@@ -94,9 +111,13 @@ tasks {
         dependsOn("copyForDocker")
     }
     named<ShadowJar>("shadowJar") {
-        manifest {
-            attributes["Main-Class"] = "net.cytonic.cytosis.Cytosis"
-        }
+        dependsOn(
+            "generateRuntimeDownloadResourceForRuntimeDownloadOnly",
+            "generateRuntimeDownloadResourceForRuntimeDownload"
+        )
+//        manifest {
+//            attributes["Main-Class"] = "net.cytonic.cytosis.BootStrap"
+//        }
         mergeServiceFiles()
         archiveFileName.set("cytosis.jar")
         archiveClassifier.set("")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,6 +61,9 @@ dependencies {
 }
 
 tasks.withType<Javadoc> {
+    dependsOn("generateRuntimeDownloadResourceForRuntimeDownload")
+    dependsOn("generateRuntimeDownloadResourceForRuntimeDownloadOnly")
+
     val javadocOptions = options as CoreJavadocOptions
     javadocOptions.addStringOption("source", "21")
 }
@@ -237,7 +240,7 @@ publishing {
             groupId = project.group.toString()
             artifactId = project.name
             version = project.version.toString()
-            artifact(tasks["jar"])
+            artifact(thinShadow.get().archiveFile)
             artifact(javadocJar)
             artifact(sourcesJar)
         }

--- a/docker/basic/Dockerfile
+++ b/docker/basic/Dockerfile
@@ -13,7 +13,7 @@ ARG OTEL_HOST
 # Copy cytosis Jar
 ADD ../../build/libs/cytosis.jar .
 
-ADD ../../build/libs/config.toml .
+ADD ../../config.toml .
 
 # Expose the port
 EXPOSE 25567

--- a/src/main/java/net/cytonic/cytosis/Cytosis.java
+++ b/src/main/java/net/cytonic/cytosis/Cytosis.java
@@ -8,8 +8,6 @@ import eu.koboo.minestom.invue.core.MinestomInvue;
 import io.github.togar2.pvp.MinestomPvP;
 import io.github.togar2.pvp.feature.CombatFeatureSet;
 import io.github.togar2.pvp.feature.CombatFeatures;
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.Tracer;
 import lombok.Getter;
 import lombok.Setter;
 import net.cytonic.cytosis.commands.CommandHandler;
@@ -170,18 +168,9 @@ public final class Cytosis {
         if (!flags.contains("--no-metrics")) {
             CytosisOpenTelemetry.setup();
         }
-        // start metrics as the very first thing
-        Span span;
-        if (metricsEnabled) {
-            Tracer tracer = CytosisOpenTelemetry.getTracer("Cytosis");
-            span = tracer.spanBuilder("startup").startSpan();
-        } else {
-            span = null; // effectively final
-        }
         metricsManager = new MetricsManager();
         // handle uncaught exceptions
         Thread.setDefaultUncaughtExceptionHandler((t, e) -> {
-            e.printStackTrace(System.err);
             Logger.error("Uncaught exception in thread " + t.getName(), e);
         });
 
@@ -219,29 +208,165 @@ public final class Cytosis {
 
         // Everything after this point depends on config contents
         Logger.info("Initializing file manager");
-        fileManager.init().whenComplete((ignored, throwable) -> {
-            if (throwable != null) {
-                Logger.error("An error occurred whilst initializing the file manager!", throwable);
-            } else {
-                Logger.info("File manager initialized!");
-                CytosisSettings.loadEnvironmentVariables();
-                CytosisSettings.loadCommandArgs();
-                if (CytosisSettings.SERVER_PROXY_MODE) {
-                    Logger.info("Enabling velocity!");
-                    VelocityProxy.enable(CytosisSettings.SERVER_SECRET);
-                } else mojangAuth();
-                Logger.info("Completing nonessential startup tasks.");
+        fileManager.init();
 
-                try {
-                    if (metricsEnabled && span != null) {
-                        span.addEvent("Essential startup tasks completed", Instant.now());
-                    }
-                    completeNonEssentialTasks(start, span);
-                } catch (Exception e) {
-                    Logger.error("ERR: ", e);
-                }
+        Logger.info("Loading Cytosis Settings");
+        CytosisSettings.loadEnvironmentVariables();
+        CytosisSettings.loadCommandArgs();
+
+        Logger.info("Initializing database");
+        databaseManager = new DatabaseManager();
+        databaseManager.setupDatabases();
+
+        if (CytosisSettings.SERVER_PROXY_MODE) {
+            Logger.info("Enabling velocity!");
+            VelocityProxy.enable(CytosisSettings.SERVER_SECRET);
+        } else mojangAuth();
+
+        Logger.info("Initializing block placements");
+        BlockPlacementUtils.init();
+
+        Logger.info("Initializing view registry");
+        VIEW_REGISTRY.enable();
+
+        Logger.info("Starting NATS manager!");
+        natsManager = new NatsManager();
+        if (!flags.contains("--ci-test")) natsManager.setup(); // don't connect to NATS in compile and run checks
+
+        // commands
+        MinecraftServer.getPacketListenerManager().setPlayListener(ClientSignedCommandChatPacket.class, (packet, p) -> MinecraftServer.getPacketListenerManager().processClientPacket(new ClientCommandChatPacket(packet.message()), p.getPlayerConnection(), p.getPlayerConnection().getConnectionState()));
+
+        if (metricsEnabled) {
+            Logger.info("Starting metric hooks");
+            MetricsHooks.init();
+        }
+
+
+        Thread.ofVirtual().name("Cs-WorldLoader").start(Cytosis::loadWorld);
+
+        Logger.info("Initializing server commands");
+        commandHandler = new CommandHandler();
+        commandHandler.setupConsole();
+        commandHandler.registerCytosisCommands();
+
+        Logger.info("Setting up command disabling");
+        commandDisablingManager = new CommandDisablingManager();
+        commandDisablingManager.loadRemotes();
+        commandDisablingManager.setupConsumers();
+
+
+        Logger.info("Setting up event handlers");
+        eventHandler = new EventHandler(MinecraftServer.getGlobalEventHandler());
+        eventHandler.init();
+
+        Logger.info("Loading player preferences");
+        preferenceManager = new PreferenceManager();
+
+        Logger.info("Initializing server events");
+        ServerEventListeners.initServerEvents();
+
+        Logger.info("Loading vanish manager!");
+        vanishManager = new VanishManager();
+        Runtime.getRuntime().addShutdownHook(new Thread(Cytosis::shutdownHandler));
+        MinecraftServer.getSchedulerManager().buildShutdownTask(Cytosis::shutdownHandler);
+
+        Logger.info("Starting Player list manager");
+        playerListManager = new PlayerListManager();
+
+        Logger.info("Starting Friend manager!");
+        friendManager = new FriendManager();
+        friendManager.init();
+
+        Logger.info("Initializing Rank Manager");
+        rankManager = new RankManager();
+        rankManager.init();
+
+        Logger.info("Creating sideboard manager!");
+        sideboardManager = new SideboardManager();
+        sideboardManager.updateBoards();
+
+        Logger.info("Starting NPC manager!");
+        npcManager = new NPCManager();
+
+        try {
+            if (CytosisSettings.SERVER_PROXY_MODE) {
+                Logger.info("Loading network setup!");
+                cytonicNetwork = new CytonicNetwork();
+                cytonicNetwork.importData();
+                cytonicNetwork.getServers().put(SERVER_ID, new CytonicServer(Utils.getServerIP(), SERVER_ID, CytosisSettings.SERVER_PORT));
             }
-        });
+        } catch (Exception e) {
+            Logger.error("An error occurred whilst loading network setup!", e);
+        }
+
+        Logger.info("Starting cooldown managers");
+        networkCooldownManager = new NetworkCooldownManager(databaseManager.getRedisDatabase());
+        networkCooldownManager.importFromRedis();
+        Logger.info("Started network cooldown manager");
+
+        Logger.info("starting actionbar manager");
+        actionbarManager = new ActionbarManager();
+        actionbarManager.init();
+
+        Logger.info("Starting Snooper Manager");
+        snooperManager = new SnooperManager();
+        Logger.info("Loading snooper channels from redis");
+        snooperManager.loadChannelsFromRedis();
+        Logger.info("Loading Cytosis snoops");
+        // load snoops
+        snooperManager.registerChannel(CytosisSnoops.PLAYER_BAN);
+        snooperManager.registerChannel(CytosisSnoops.PLAYER_UNBAN);
+        snooperManager.registerChannel(CytosisSnoops.PLAYER_KICK);
+        snooperManager.registerChannel(CytosisSnoops.PLAYER_UNMUTE);
+        snooperManager.registerChannel(CytosisSnoops.PLAYER_MUTE);
+        snooperManager.registerChannel(CytosisSnoops.PLAYER_WARN);
+        snooperManager.registerChannel(CytosisSnoops.SERVER_ERROR);
+        snooperManager.registerChannel(CytosisSnoops.CHANGE_RANK);
+
+        try {
+            Logger.info("Loading PVP");
+            MinestomPvP.init();
+            CombatFeatureSet modernVanilla = CombatFeatures.modernVanilla();
+            MinecraftServer.getGlobalEventHandler().addChild(modernVanilla.createNode());
+            MinecraftServer.getConnectionManager().setPlayerProvider(CytosisPlayer::new);
+        } catch (Exception e) {
+            Logger.error("error", e);
+        }
+
+        //
+        // PLUGIN LOADING IS ALWAYS LAST!!!!
+        // (This is so any apis it depends on are guarenteed to already by loaded!)
+        //
+        Logger.info("Initializing Plugin Manager!");
+        pluginManager = new PluginManager();
+        Logger.info("Loading plugins!");
+        try {
+            if (new File("plugins").exists() && new File("plugins").isDirectory()) {
+                pluginManager.loadPlugins(Path.of("plugins"));
+            } else {
+                new File("plugins").mkdir();
+                Logger.info("Created plugins directory!");
+            }
+        } catch (Exception e) {
+            Logger.error("An error occurred whilst loading plugins!", e);
+            throw new RuntimeException("An error occurred whilst loading plugins!", e);
+        }
+
+        // Start the server
+        Logger.info("Server started on port " + CytosisSettings.SERVER_PORT);
+        minecraftServer.start("0.0.0.0", CytosisSettings.SERVER_PORT);
+        MinecraftServer.getExceptionManager().setExceptionHandler(e -> Logger.error("Uncaught exception: ", e));
+
+        natsManager.sendStartup();
+
+        long end = System.currentTimeMillis();
+        Logger.info("Server started in " + (end - start) + "ms!");
+        Logger.info("Server id = " + SERVER_ID);
+
+        if (flags.contains("--ci-test")) {
+            Logger.info("Stopping server due to '--ci-test' flag.");
+            MinecraftServer.stopCleanly();
+        }
     }
 
     /**
@@ -316,176 +441,6 @@ public final class Cytosis {
                 defaultInstance.setChunkSupplier(LightingChunk::new);
                 defaultInstance.enableAutoChunkLoad(true);
                 Logger.info("World loaded!");
-            }
-        });
-    }
-
-    /**
-     * Completes nonessential startup tasks for the server
-     *
-     * @param start The time the server started
-     */
-    public static void completeNonEssentialTasks(long start, Span span) {
-        Logger.info("Initializing block placements");
-        BlockPlacementUtils.init();
-
-        Logger.info("Initializing view registry");
-        VIEW_REGISTRY.enable();
-
-        Logger.info("Starting NATS manager!");
-        natsManager = new NatsManager();
-        if (!flags.contains("--ci-test")) natsManager.setup(); // don't connect to NATS in compile and run checks
-
-        // commands
-        MinecraftServer.getPacketListenerManager().setPlayListener(ClientSignedCommandChatPacket.class, (packet, p) -> MinecraftServer.getPacketListenerManager().processClientPacket(new ClientCommandChatPacket(packet.message()), p.getPlayerConnection(), p.getPlayerConnection().getConnectionState()));
-
-        if (metricsEnabled) {
-            Logger.info("Starting metric hooks");
-            MetricsHooks.init();
-        }
-
-        Logger.info("Initializing database");
-        databaseManager = new DatabaseManager();
-        databaseManager.setupDatabases().whenComplete((ignored, throwable) -> {
-            if (throwable != null) {
-                Logger.error("An error occurred whilst initializing the database!", throwable);
-                return;
-            }
-
-            if (metricsEnabled && span != null) span.addEvent("Connected to database", Instant.now());
-
-            Thread.ofVirtual().name("WorldLoader").start(Cytosis::loadWorld);
-
-            Logger.info("Initializing server commands");
-            commandHandler = new CommandHandler();
-            commandHandler.setupConsole();
-            commandHandler.registerCytosisCommands();
-
-            Logger.info("Setting up command disabling");
-            commandDisablingManager = new CommandDisablingManager();
-            commandDisablingManager.loadRemotes();
-            commandDisablingManager.setupConsumers();
-
-
-            Logger.info("Database initialized!");
-            Logger.info("Setting up event handlers");
-            eventHandler = new EventHandler(MinecraftServer.getGlobalEventHandler());
-            eventHandler.init();
-
-            Logger.info("Loading player preferences");
-            preferenceManager = new PreferenceManager();
-
-            Logger.info("Initializing server events");
-            ServerEventListeners.initServerEvents();
-
-            Logger.info("Loading vanish manager!");
-            vanishManager = new VanishManager();
-            Runtime.getRuntime().addShutdownHook(new Thread(Cytosis::shutdownHandler));
-            MinecraftServer.getSchedulerManager().buildShutdownTask(Cytosis::shutdownHandler);
-
-            Logger.info("Starting Player list manager");
-            playerListManager = new PlayerListManager();
-
-            Logger.info("Starting Friend manager!");
-            friendManager = new FriendManager();
-            friendManager.init();
-
-            Logger.info("Initializing Rank Manager");
-            rankManager = new RankManager();
-            rankManager.init();
-
-            Logger.info("Creating sideboard manager!");
-            sideboardManager = new SideboardManager();
-            sideboardManager.updateBoards();
-
-            Logger.info("Starting NPC manager!");
-            npcManager = new NPCManager();
-
-            try {
-                if (CytosisSettings.SERVER_PROXY_MODE) {
-                    Logger.info("Loading network setup!");
-                    cytonicNetwork = new CytonicNetwork();
-                    cytonicNetwork.importData();
-                    cytonicNetwork.getServers().put(SERVER_ID, new CytonicServer(Utils.getServerIP(), SERVER_ID, CytosisSettings.SERVER_PORT));
-                }
-            } catch (Exception e) {
-                Logger.error("An error occurred whilst loading network setup!", e);
-            }
-
-            Logger.info("Starting cooldown managers");
-            networkCooldownManager = new NetworkCooldownManager(databaseManager.getRedisDatabase());
-            networkCooldownManager.importFromRedis();
-            Logger.info("Started network cooldown manager");
-
-            Logger.info("starting actionbar manager");
-            actionbarManager = new ActionbarManager();
-            actionbarManager.init();
-
-            Logger.info("Starting Snooper Manager");
-            snooperManager = new SnooperManager();
-            Logger.info("Loading snooper channels from redis");
-            snooperManager.loadChannelsFromRedis();
-            Logger.info("Loading Cytosis snoops");
-            // load snoops
-            snooperManager.registerChannel(CytosisSnoops.PLAYER_BAN);
-            snooperManager.registerChannel(CytosisSnoops.PLAYER_UNBAN);
-            snooperManager.registerChannel(CytosisSnoops.PLAYER_KICK);
-            snooperManager.registerChannel(CytosisSnoops.PLAYER_UNMUTE);
-            snooperManager.registerChannel(CytosisSnoops.PLAYER_MUTE);
-            snooperManager.registerChannel(CytosisSnoops.PLAYER_WARN);
-            snooperManager.registerChannel(CytosisSnoops.SERVER_ERROR);
-            snooperManager.registerChannel(CytosisSnoops.CHANGE_RANK);
-
-            try {
-                Logger.info("Loading PVP");
-                MinestomPvP.init();
-                CombatFeatureSet modernVanilla = CombatFeatures.modernVanilla();
-                MinecraftServer.getGlobalEventHandler().addChild(modernVanilla.createNode());
-                MinecraftServer.getConnectionManager().setPlayerProvider(CytosisPlayer::new);
-            } catch (Exception e) {
-                Logger.error("error", e);
-            }
-
-            //
-            // PLUGIN LOADING IS ALWAYS LAST!!!!
-            // (This is so any apis it depends on are guarenteed to already by loaded!)
-            //
-            Logger.info("Initializing Plugin Manager!");
-            pluginManager = new PluginManager();
-            Logger.info("Loading plugins!");
-            try {
-                if (new File("plugins").exists() && new File("plugins").isDirectory()) {
-                    pluginManager.loadPlugins(Path.of("plugins"));
-                } else {
-                    new File("plugins").mkdir();
-                    Logger.info("Created plugins directory!");
-                }
-            } catch (Exception e) {
-                Logger.error("An error occurred whilst loading plugins!", e);
-                throw new RuntimeException("An error occurred whilst loading plugins!", e);
-            }
-            if (metricsEnabled && span != null) span.addEvent("Plugins loaded", Instant.now());
-
-            // Start the server
-            Logger.info("Server started on port " + CytosisSettings.SERVER_PORT);
-            minecraftServer.start("0.0.0.0", CytosisSettings.SERVER_PORT);
-            MinecraftServer.getExceptionManager().setExceptionHandler(e -> Logger.error("Uncaught exception", e));
-            try {
-                natsManager.sendStartup();
-            } catch (Exception e) {
-                Logger.error("ERROR: ", e);
-            }
-            long end = System.currentTimeMillis();
-            Logger.info("Server started in " + (end - start) + "ms!");
-            Logger.info("Server group = " + serverGroup.group());
-            if (metricsEnabled && span != null) {
-                span.addEvent("Server started in " + (end - start) + "ms.", Instant.now());
-                span.end(Instant.now());
-            }
-
-            if (flags.contains("--ci-test")) {
-                Logger.info("Stopping server due to '--ci-test' flag.");
-                MinecraftServer.stopCleanly();
             }
         });
     }

--- a/src/main/java/net/cytonic/cytosis/bootstrap/BootstrapClassLoader.java
+++ b/src/main/java/net/cytonic/cytosis/bootstrap/BootstrapClassLoader.java
@@ -1,0 +1,37 @@
+package net.cytonic.cytosis.bootstrap;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+public class BootstrapClassLoader extends URLClassLoader {
+
+
+    public BootstrapClassLoader() {
+        super("Bootstrap Class Loader", new URL[]{}, BootstrapClassLoader.class.getClassLoader());
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        if (name.startsWith("java.") || name.startsWith("javax.")) {
+            return super.loadClass(name, resolve); // delegate to bootstrap for core classes
+        }
+
+        synchronized (getClassLoadingLock(name)) {
+            Class<?> c = findLoadedClass(name);
+            if (c == null) {
+                try {
+                    c = findClass(name); // load from our JARs
+                } catch (ClassNotFoundException e) {
+                    c = super.loadClass(name, resolve);
+                }
+            }
+            if (resolve) resolveClass(c);
+            return c;
+        }
+    }
+
+    @Override
+    public void addURL(URL url) {
+        super.addURL(url);
+    }
+}

--- a/src/main/java/net/cytonic/cytosis/bootstrap/BootstrapClasspathAppender.java
+++ b/src/main/java/net/cytonic/cytosis/bootstrap/BootstrapClasspathAppender.java
@@ -1,0 +1,26 @@
+package net.cytonic.cytosis.bootstrap;
+
+import dev.vankka.dependencydownload.classpath.ClasspathAppender;
+import net.cytonic.cytosis.logging.BootstrapLogger;
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.file.Path;
+
+public class BootstrapClasspathAppender implements ClasspathAppender {
+
+    public static final BootstrapClassLoader CLASSLOADER = new BootstrapClassLoader();
+
+    @Override
+    public void appendFileToClasspath(@NotNull Path path) {
+        if (System.getProperty("cytosis.log-bootstrap-appending") != null) {
+            BootstrapLogger.info("Appending path to classpath: " + path);
+        }
+
+        try {
+            CLASSLOADER.addURL(path.toUri().toURL());
+        } catch (Exception e) {
+            BootstrapLogger.error("Failed to add URL to classpath", e);
+            throw new RuntimeException("Failed to add URL to classloader", e);
+        }
+    }
+}

--- a/src/main/java/net/cytonic/cytosis/bootstrap/Bootstrapper.java
+++ b/src/main/java/net/cytonic/cytosis/bootstrap/Bootstrapper.java
@@ -18,9 +18,6 @@ import java.util.concurrent.Executors;
 
 public class Bootstrapper {
     public static void main(String[] args) throws URISyntaxException, IOException {
-        BootstrapLogger.info("Starting boostrapper");
-        BootstrapLogger.info("Classpath: " + System.getProperty("java.class.path"));
-
         if (!BuildInfo.DEPENDENCIES_BUNDLED) {
             long start = System.currentTimeMillis();
             BootstrapLogger.info("Loading dependencies");

--- a/src/main/java/net/cytonic/cytosis/bootstrap/Bootstrapper.java
+++ b/src/main/java/net/cytonic/cytosis/bootstrap/Bootstrapper.java
@@ -1,0 +1,69 @@
+package net.cytonic.cytosis.bootstrap;
+
+import dev.vankka.dependencydownload.DependencyManager;
+import dev.vankka.dependencydownload.repository.StandardRepository;
+import dev.vankka.dependencydownload.resource.DependencyDownloadResource;
+import net.cytonic.cytosis.Cytosis;
+import net.cytonic.cytosis.logging.BootstrapLogger;
+import net.cytonic.cytosis.utils.BuildInfo;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+public class Bootstrapper {
+    public static void main(String[] args) throws URISyntaxException, IOException {
+        BootstrapLogger.info("Starting boostrapper");
+        BootstrapLogger.info("Classpath: " + System.getProperty("java.class.path"));
+
+        if (!BuildInfo.DEPENDENCIES_BUNDLED) {
+            long start = System.currentTimeMillis();
+            BootstrapLogger.info("Loading dependencies");
+            DependencyManager manager = new DependencyManager(Paths.get("cache"));
+
+            Executor executor = Executors.newFixedThreadPool(3);
+
+            manager.loadFromResource(new DependencyDownloadResource(Bootstrapper.class.getResource("/runtimeDownloadOnly.txt").toURI().toURL()));
+            manager.loadFromResource(new DependencyDownloadResource(Bootstrapper.class.getResource("/runtimeDownload.txt").toURI().toURL()));
+            manager.downloadAll(executor, List.of(
+                            new StandardRepository("https://repo1.maven.org/maven2/"),
+                            new StandardRepository("https://repo.foxikle.dev/cytonic/"),
+                            new StandardRepository("https://jitpack.io/")
+                    ))
+                    .thenAccept(unused -> {
+                        manager.loadAll(executor, new BootstrapClasspathAppender()).join(); // ClasspathAppender is a interface that you need to implement to append a Path to the classpath
+                        long end = System.currentTimeMillis();
+                        BootstrapLogger.info("Loaded dependencies in " + (end - start) + "ms.");
+                        Thread.currentThread().setContextClassLoader(BootstrapClasspathAppender.CLASSLOADER);
+                        BootstrapLogger.info("Loading Cytosis Core classes");
+                        try {
+                            File jarFile = new File(Bootstrapper.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+                            URL jarUrl = jarFile.toURI().toURL();
+                            BootstrapClasspathAppender.CLASSLOADER.addURL(jarUrl);
+                            Class<?> mainClass = BootstrapClasspathAppender.CLASSLOADER.loadClass("net.cytonic.cytosis.Cytosis");
+                            BootstrapLogger.info("Starting Cytosis!");
+                            try {
+                                mainClass.getDeclaredMethod("main", String[].class).invoke(null, (Object) args);
+                            } catch (Exception e) {
+                                BootstrapLogger.error("Caught exception: ", e);
+                            }
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    })
+                    .exceptionally(throwable -> {
+                        BootstrapLogger.error("Failed to load dependency ", throwable);
+                        return null;
+                    });
+        } else {
+            BootstrapLogger.info("Skipping bootstraping of dependencies. Starting Cytosis!");
+            // start cytosis
+            Cytosis.main(args);
+        }
+    }
+}

--- a/src/main/java/net/cytonic/cytosis/commands/CytosisCommand.java
+++ b/src/main/java/net/cytonic/cytosis/commands/CytosisCommand.java
@@ -2,7 +2,6 @@ package net.cytonic.cytosis.commands;
 
 import lombok.Getter;
 import lombok.Setter;
-import net.cytonic.cytosis.logging.Logger;
 import net.minestom.server.command.CommandSender;
 import net.minestom.server.command.builder.Command;
 import net.minestom.server.command.builder.CommandExecutor;
@@ -53,12 +52,10 @@ public class CytosisCommand extends Command {
     @Override
     public void setDefaultExecutor(@Nullable CommandExecutor executor) {
         super.setDefaultExecutor((s, c) -> {
-            Logger.debug("Disabled: " + disabled);
             if (checkDisabled(s)) {
                 s.sendMessage(CommandUtils.COMMAND_DISABLED);
                 return;
             }
-            Logger.debug("Still continuing");
 
             if (executor != null) {
                 executor.apply(s, c);

--- a/src/main/java/net/cytonic/cytosis/commands/movement/LobbyCommand.java
+++ b/src/main/java/net/cytonic/cytosis/commands/movement/LobbyCommand.java
@@ -10,7 +10,7 @@ public class LobbyCommand extends CytosisCommand {
         super("lobby", "l");
         setDefaultExecutor((sender, context) -> {
             if (!(sender instanceof CytosisPlayer player)) return;
-            Cytosis.getNatsManager().sendPlayerToServer(player.getUuid(), "cytonic", "lobby", "a Lobby");
+            Cytosis.getNatsManager().sendPlayerToGenericServer(player.getUuid(), "cytonic", "lobby", "a Lobby");
         });
     }
 }

--- a/src/main/java/net/cytonic/cytosis/commands/movement/PlayCommand.java
+++ b/src/main/java/net/cytonic/cytosis/commands/movement/PlayCommand.java
@@ -17,9 +17,9 @@ public class PlayCommand extends CytosisCommand {
             if (!(sender instanceof CytosisPlayer player)) return;
             switch (context.get(word).toLowerCase()) {
                 case "gg", "gilded", "gilded_gorge" ->
-                        Cytosis.getNatsManager().sendPlayerToServer(player.getUuid(), "gilded_gorge", "hub", "Gilded Gorge");
+                        Cytosis.getNatsManager().sendPlayerToGenericServer(player.getUuid(), "gilded_gorge", "hub", "Gilded Gorge");
                 case "bw", "bedwars" ->//todo: Some sort of logic for game queuing
-                        Cytosis.getNatsManager().sendPlayerToServer(player.getUuid(), "bedwars", "solos", "BedWars");
+                        Cytosis.getNatsManager().sendPlayerToGenericServer(player.getUuid(), "bedwars", "solos", "BedWars");
 
             }
         }, word);

--- a/src/main/java/net/cytonic/cytosis/data/DatabaseManager.java
+++ b/src/main/java/net/cytonic/cytosis/data/DatabaseManager.java
@@ -3,8 +3,6 @@ package net.cytonic.cytosis.data;
 import lombok.Getter;
 import net.cytonic.cytosis.logging.Logger;
 
-import java.util.concurrent.CompletableFuture;
-
 /**
  * A class managing databases
  */
@@ -34,21 +32,17 @@ public class DatabaseManager {
      *
      * @return A future that completes once all databases are connected
      */
-    public CompletableFuture<Void> setupDatabases() {
-        CompletableFuture<Void> future = new CompletableFuture<>();
+    public void setupDatabases() {
         Logger.info("Connecting to MySQL Database.");
         mysqlDatabase = new MysqlDatabase();
-        mysqlDatabase.connect().whenComplete((ignored, throwable) -> future.complete(null));
+
+        mysqlDatabase.connect();
         mysqlDatabase.createTables();
 
         Logger.info("Connecting to the Redis Database.");
-        try {
-            redisDatabase = new RedisDatabase(); // it handles initialization in the constructor
-        } catch (Exception ex) {
-            Logger.error("An error occurred!", ex);
-        }
+        redisDatabase = new RedisDatabase(); // it handles initialization in the constructor
+
 
         Logger.info("All Databases connected.");
-        return future;
     }
 }

--- a/src/main/java/net/cytonic/cytosis/data/DatabaseManager.java
+++ b/src/main/java/net/cytonic/cytosis/data/DatabaseManager.java
@@ -29,8 +29,6 @@ public class DatabaseManager {
 
     /**
      * Sets up the databases by creating tables and creating connections
-     *
-     * @return A future that completes once all databases are connected
      */
     public void setupDatabases() {
         Logger.info("Connecting to MySQL Database.");

--- a/src/main/java/net/cytonic/cytosis/data/MysqlDatabase.java
+++ b/src/main/java/net/cytonic/cytosis/data/MysqlDatabase.java
@@ -37,12 +37,7 @@ public class MysqlDatabase {
     private final String username;
     private final String password;
     private final boolean ssl;
-    /**
-     * -- GETTER --
-     * Gets the connection
-     *
-     * @return the connection to the database
-     */
+
     @Getter
     private Connection connection;
 
@@ -60,7 +55,7 @@ public class MysqlDatabase {
         this.ssl = CytosisSettings.DATABASE_USE_SSL;
         try {
             Class.forName("com.mysql.cj.jdbc.Driver");
-        } catch (ClassNotFoundException e) {
+        } catch (Exception e) {
             Logger.error("Failed to load database driver", e);
         }
     }
@@ -75,42 +70,32 @@ public class MysqlDatabase {
     }
 
     /**
-     * connects to the database
-     *
-     * @return a future that completes when the connection is successful
+     * Connects to the database, blocking until completed
      */
-    public CompletableFuture<Void> connect() {
-        CompletableFuture<Void> future = new CompletableFuture<>();
-        worker.submit(() -> {
-            if (!isConnected()) {
-                try {
-                    connection = DriverManager.getConnection("jdbc:mysql://" + host + ":" + port + "/" + database + "?useSSL=" + ssl + "&autoReconnect=true&allowPublicKeyRetrieval=true", username, password);
-                    Logger.info("Successfully connected to the MySQL Database!");
-                    future.complete(null);
-                } catch (SQLException e) {
-                    Logger.error("Invalid Database Credentials!", e);
-                    MinecraftServer.stopCleanly();
-                    future.completeExceptionally(e);
-                }
+    public void connect() {
+        if (!isConnected()) {
+            try {
+                connection = DriverManager.getConnection("jdbc:mysql://" + host + ":" + port + "/" + database + "?useSSL=" + ssl + "&autoReconnect=true&allowPublicKeyRetrieval=true", username, password);
+                Logger.info("Successfully connected to the MySQL Database!");
+            } catch (SQLException e) {
+                Logger.error("Invalid Database Credentials!", e);
+                MinecraftServer.stopCleanly();
             }
-        });
-        return future;
+        }
     }
 
     /**
      * Disconnects from the database server
      */
     public void disconnect() {
-        worker.submit(() -> {
-            if (isConnected()) {
-                try {
-                    connection.close();
-                    Logger.info("Database connection closed!");
-                } catch (SQLException e) {
-                    Logger.error("An error occurred whilst disconnecting from the database. Please report the following stacktrace to CytonicMC: ", e);
-                }
+        if (isConnected()) {
+            try {
+                connection.close();
+                Logger.info("Database connection closed!");
+            } catch (SQLException e) {
+                Logger.error("An error occurred whilst disconnecting from the database. Please report the following stacktrace to CytonicMC: ", e);
             }
-        });
+        }
     }
 
     /**
@@ -132,100 +117,91 @@ public class MysqlDatabase {
      * Creates the chat messages table
      */
     private void createChatTable() {
-        worker.submit(() -> {
-            if (isConnected()) {
-                PreparedStatement ps;
-                try {
-                    ps = getConnection().prepareStatement("CREATE TABLE IF NOT EXISTS cytonic_chat (id INT NOT NULL AUTO_INCREMENT, timestamp TIMESTAMP, uuid VARCHAR(36), message TEXT, PRIMARY KEY(id))");
-                    ps.executeUpdate();
-                } catch (SQLException e) {
-                    Logger.error("An error occurred whilst creating the `cytonic_chat` table.", e);
-                }
+        if (isConnected()) {
+            PreparedStatement ps;
+            try {
+                ps = getConnection().prepareStatement("CREATE TABLE IF NOT EXISTS cytonic_chat (id INT NOT NULL AUTO_INCREMENT, timestamp TIMESTAMP, uuid VARCHAR(36), message TEXT, PRIMARY KEY(id))");
+                ps.executeUpdate();
+            } catch (SQLException e) {
+                Logger.error("An error occurred whilst creating the `cytonic_chat` table.", e);
             }
-        });
+        }
+
     }
 
     /**
      * Creates the ranks table
      */
     private void createRanksTable() {
-        worker.submit(() -> {
-            if (isConnected()) {
-                PreparedStatement ps;
-                try {
-                    ps = getConnection().prepareStatement("CREATE TABLE IF NOT EXISTS cytonic_ranks (uuid VARCHAR(36), rank_id VARCHAR(16), PRIMARY KEY(uuid))");
-                    ps.executeUpdate();
-                } catch (SQLException e) {
-                    Logger.error("An error occurred whilst creating the `cytonic_ranks` table.", e);
-                }
+        if (isConnected()) {
+            PreparedStatement ps;
+            try {
+                ps = getConnection().prepareStatement("CREATE TABLE IF NOT EXISTS cytonic_ranks (uuid VARCHAR(36), rank_id VARCHAR(16), PRIMARY KEY(uuid))");
+                ps.executeUpdate();
+            } catch (SQLException e) {
+                Logger.error("An error occurred whilst creating the `cytonic_ranks` table.", e);
             }
-        });
+        }
+
     }
 
     /**
      * Creates the bans table
      */
     private void createBansTable() {
-        worker.submit(() -> {
-            if (isConnected()) {
-                PreparedStatement ps;
-                try {
-                    ps = getConnection().prepareStatement("CREATE TABLE IF NOT EXISTS cytonic_bans (uuid VARCHAR(36), to_expire VARCHAR(100), reason TINYTEXT, PRIMARY KEY(uuid))");
-                    ps.executeUpdate();
-                } catch (SQLException e) {
-                    Logger.error("An error occurred whilst creating the `cytonic_bans` table.", e);
-                }
+        if (isConnected()) {
+            PreparedStatement ps;
+            try {
+                ps = getConnection().prepareStatement("CREATE TABLE IF NOT EXISTS cytonic_bans (uuid VARCHAR(36), to_expire VARCHAR(100), reason TINYTEXT, PRIMARY KEY(uuid))");
+                ps.executeUpdate();
+            } catch (SQLException e) {
+                Logger.error("An error occurred whilst creating the `cytonic_bans` table.", e);
             }
-        });
+        }
+
     }
 
     /**
      * Creates the player data table
      */
     private void createPlayersTable() {
-        worker.submit(() -> {
-            if (isConnected()) {
-                PreparedStatement ps;
-                try {
-                    ps = getConnection().prepareStatement("CREATE TABLE IF NOT EXISTS cytonic_players (uuid VARCHAR(36), name VARCHAR(16), PRIMARY KEY(uuid))");
-                    ps.executeUpdate();
-                } catch (SQLException e) {
-                    Logger.error("An error occurred whilst creating the `cytonic_players` table.", e);
-                }
+        if (isConnected()) {
+            PreparedStatement ps;
+            try {
+                ps = getConnection().prepareStatement("CREATE TABLE IF NOT EXISTS cytonic_players (uuid VARCHAR(36), name VARCHAR(16), PRIMARY KEY(uuid))");
+                ps.executeUpdate();
+            } catch (SQLException e) {
+                Logger.error("An error occurred whilst creating the `cytonic_players` table.", e);
             }
-        });
+        }
     }
 
     /**
      * Creates the world table
      */
     public void createWorldTable() {
-        worker.submit(() -> {
-            if (isConnected()) {
-                PreparedStatement ps;
-                try {
-                    ps = getConnection().prepareStatement("CREATE TABLE IF NOT EXISTS cytonic_worlds (world_name TEXT, world_type TEXT, last_modified TIMESTAMP, world_data MEDIUMBLOB, spawn_point TEXT, extra_data TEXT)");
-                    ps.executeUpdate();
-                } catch (SQLException e) {
-                    Logger.error("An error occurred whilst creating the `cytonic_worlds` table.", e);
-                }
+        if (isConnected()) {
+            PreparedStatement ps;
+            try {
+                ps = getConnection().prepareStatement("CREATE TABLE IF NOT EXISTS cytonic_worlds (world_name TEXT, world_type TEXT, last_modified TIMESTAMP, world_data MEDIUMBLOB, spawn_point TEXT, extra_data TEXT)");
+                ps.executeUpdate();
+            } catch (SQLException e) {
+                Logger.error("An error occurred whilst creating the `cytonic_worlds` table.", e);
             }
-        });
+        }
     }
 
     /**
      * Create the player join logging table
      */
     private void createPlayerJoinsTable() {
-        worker.submit(() -> {
-            if (isConnected()) {
-                try (PreparedStatement ps = getConnection().prepareStatement("CREATE TABLE IF NOT EXISTS cytonic_player_joins (joined TIMESTAMP, uuid VARCHAR(36), ip TEXT)")) {
-                    ps.executeUpdate();
-                } catch (SQLException e) {
-                    Logger.error("An error occurred whilst creating the `cytonic_player_joins` table.", e);
-                }
+        if (isConnected()) {
+            try (PreparedStatement ps = getConnection().prepareStatement("CREATE TABLE IF NOT EXISTS cytonic_player_joins (joined TIMESTAMP, uuid VARCHAR(36), ip TEXT)")) {
+                ps.executeUpdate();
+            } catch (SQLException e) {
+                Logger.error("An error occurred whilst creating the `cytonic_player_joins` table.", e);
             }
-        });
+        }
     }
 
 
@@ -233,48 +209,42 @@ public class MysqlDatabase {
      * Creates the bans table
      */
     private void createMutesTable() {
-        worker.submit(() -> {
-            if (isConnected()) {
-                PreparedStatement ps;
-                try {
-                    ps = getConnection().prepareStatement("CREATE TABLE IF NOT EXISTS cytonic_mutes (uuid VARCHAR(36), to_expire VARCHAR(100), PRIMARY KEY(uuid))");
-                    ps.executeUpdate();
-                } catch (SQLException e) {
-                    Logger.error("An error occurred whilst creating the `cytonic_mutes` table.", e);
-                }
+        if (isConnected()) {
+            PreparedStatement ps;
+            try {
+                ps = getConnection().prepareStatement("CREATE TABLE IF NOT EXISTS cytonic_mutes (uuid VARCHAR(36), to_expire VARCHAR(100), PRIMARY KEY(uuid))");
+                ps.executeUpdate();
+            } catch (SQLException e) {
+                Logger.error("An error occurred whilst creating the `cytonic_mutes` table.", e);
             }
-        });
+        }
     }
 
     /**
      * Creates the player messages table
      */
     private void createPlayerMessagesTable() {
-        worker.submit(() -> {
-            if (isConnected()) {
-                PreparedStatement ps;
-                try {
-                    ps = getConnection().prepareStatement("CREATE TABLE IF NOT EXISTS cytonic_player_messages (id INT NOT NULL AUTO_INCREMENT, timestamp TIMESTAMP, sender VARCHAR(36), target VARCHAR(36), message TEXT, PRIMARY KEY(id))");
-                    ps.executeUpdate();
-                } catch (SQLException e) {
-                    Logger.error("An error occurred whilst creating the `cytonic_player_messages` table.", e);
-                }
+        if (isConnected()) {
+            PreparedStatement ps;
+            try {
+                ps = getConnection().prepareStatement("CREATE TABLE IF NOT EXISTS cytonic_player_messages (id INT NOT NULL AUTO_INCREMENT, timestamp TIMESTAMP, sender VARCHAR(36), target VARCHAR(36), message TEXT, PRIMARY KEY(id))");
+                ps.executeUpdate();
+            } catch (SQLException e) {
+                Logger.error("An error occurred whilst creating the `cytonic_player_messages` table.", e);
             }
-        });
+        }
     }
 
     private void createPlayerWarnsTable() {
-        worker.submit(() -> {
-            if (isConnected()) {
-                PreparedStatement ps;
-                try {
-                    ps = getConnection().prepareStatement("CREATE TABLE IF NOT EXISTS cytonic_player_warns (id INT NOT NULL AUTO_INCREMENT, timestamp TIMESTAMP, target VARCHAR(36), actor VARCHAR(36), reason TEXT, PRIMARY KEY(id))");
-                    ps.executeUpdate();
-                } catch (SQLException e) {
-                    Logger.error("An error occurred whilst creating the `cytonic_player_warns` table.", e);
-                }
+        if (isConnected()) {
+            PreparedStatement ps;
+            try {
+                ps = getConnection().prepareStatement("CREATE TABLE IF NOT EXISTS cytonic_player_warns (id INT NOT NULL AUTO_INCREMENT, timestamp TIMESTAMP, target VARCHAR(36), actor VARCHAR(36), reason TEXT, PRIMARY KEY(id))");
+                ps.executeUpdate();
+            } catch (SQLException e) {
+                Logger.error("An error occurred whilst creating the `cytonic_player_warns` table.", e);
             }
-        });
+        }
     }
 
     public CompletableFuture<Void> addPlayerWarn(UUID actor, UUID target, String reason) {

--- a/src/main/java/net/cytonic/cytosis/dependencies/RuntimeDependencyManager.java
+++ b/src/main/java/net/cytonic/cytosis/dependencies/RuntimeDependencyManager.java
@@ -1,0 +1,5 @@
+package net.cytonic.cytosis.dependencies;
+
+public class RuntimeDependencyManager {
+    //todo: add dependency loading in a bootstrapper for plugin loading
+}

--- a/src/main/java/net/cytonic/cytosis/files/FileManager.java
+++ b/src/main/java/net/cytonic/cytosis/files/FileManager.java
@@ -22,8 +22,6 @@ public class FileManager {
 
     /**
      * Initializes the necessary files and configurations.
-     *
-     * @return A CompletableFuture representing the completion of the initialization process.
      */
     public void init() {
         createConfigFile();

--- a/src/main/java/net/cytonic/cytosis/files/FileManager.java
+++ b/src/main/java/net/cytonic/cytosis/files/FileManager.java
@@ -1,5 +1,6 @@
 package net.cytonic.cytosis.files;
 
+import lombok.NoArgsConstructor;
 import net.cytonic.cytosis.config.CytosisSettings;
 import net.cytonic.cytosis.logging.Logger;
 import org.tomlj.Toml;
@@ -10,35 +11,27 @@ import java.io.*;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 /**
  * A class handling IO and files
  */
+@NoArgsConstructor
 public class FileManager {
 
     private static final Path CONFIG_PATH = Path.of("config.toml");
-    private final ExecutorService worker;
-
-    /**
-     * The default constructor that initializes the worker thread
-     */
-    public FileManager() {
-        this.worker = Executors.newSingleThreadExecutor(Thread.ofVirtual().name("CytosisIOWorker").uncaughtExceptionHandler((t, e) -> Logger.error("An uncaught exception occoured on the thread: " + t.getName() + "", e)).factory());
-    }
 
     /**
      * Initializes the necessary files and configurations.
      *
      * @return A CompletableFuture representing the completion of the initialization process.
      */
-    public CompletableFuture<Void> init() {
-        // The create methods invoke the worker thread to create the file, so no need to here.
-        return CompletableFuture.allOf(
-                createConfigFile()
-        );
+    public void init() {
+        createConfigFile();
+        try {
+            parseToml(Toml.parse(CONFIG_PATH));
+        } catch (IOException e) {
+            Logger.error("Failed to parse config file: " + CONFIG_PATH, e);
+        }
     }
 
     /**
@@ -46,41 +39,12 @@ public class FileManager {
      *
      * @return A CompletableFuture representing the completion of the file creation process.
      */
-    public CompletableFuture<File> createConfigFile() {
-        CompletableFuture<File> future = new CompletableFuture<>();
-        worker.submit(() -> {
-            if (!CONFIG_PATH.toFile().exists()) {
-                Logger.info("No config file found, creating...");
-                try {
-                    extractResource("config.toml", CONFIG_PATH).whenComplete((file, throwable) -> {
-                        if (throwable != null) {
-                            Logger.error("An error occurred whilst extracting the config.toml file!", throwable);
-                            future.completeExceptionally(throwable);
-                            return;
-                        }
-                        try {
-                            parseToml(Toml.parse(CONFIG_PATH));
-                            future.complete(file);
-                        } catch (IllegalStateException | IOException e) {
-                            Logger.error("An error occurred whilst parsing the config.toml file!", e);
-                            future.completeExceptionally(e);
-                        }
-                    });
-                } catch (Exception e) {
-                    Logger.error("An error occurred whilst creating the config.toml file!", e);
-                    future.completeExceptionally(e);
-                }
-            } else {
-                try {
-                    parseToml(Toml.parse(CONFIG_PATH));
-                } catch (IOException e) {
-                    Logger.error("An error occurred whilst parsing the config.toml file!", e);
-                    future.completeExceptionally(e);
-                }
-                future.complete(CONFIG_PATH.toFile());
-            }
-        });
-        return future;
+    public File createConfigFile() {
+        if (!CONFIG_PATH.toFile().exists()) {
+            Logger.info("No config file found, creating...");
+            return extractResource("config.toml", CONFIG_PATH);
+        }
+        return CONFIG_PATH.toFile();
     }
 
     /**
@@ -90,56 +54,22 @@ public class FileManager {
      * @param path     The path where the extracted file will be written.
      * @return A CompletableFuture representing the completion of the file extraction process.
      */
-    public CompletableFuture<File> extractResource(String resource, Path path) {
-        CompletableFuture<File> future = new CompletableFuture<>();
-        worker.submit(() -> {
-            try {
-                InputStream stream = FileManager.class.getClassLoader().getResourceAsStream(resource);
-                if (stream == null) {
-                    throw new IllegalStateException("The resource \"" + resource + "\" does not exist!");
-                }
-                OutputStream outputStream = new FileOutputStream(path.toFile());
-                byte[] buffer = new byte[1024];
-                int length;
-                while ((length = stream.read(buffer)) > 0) outputStream.write(buffer, 0, length);
-                outputStream.close();
-                stream.close();
-                future.complete(path.toFile());
-            } catch (IOException e) {
-                Logger.error("An error occured whilst extracting the resource \"" + resource + "\"!", e);
-                future.completeExceptionally(e);
+    public File extractResource(String resource, Path path) {
+        try {
+            InputStream stream = FileManager.class.getClassLoader().getResourceAsStream(resource);
+            if (stream == null) {
+                throw new IllegalStateException("The resource \"" + resource + "\" does not exist!");
             }
-        });
-        return future;
-    }
-
-    /**
-     * Extracts a resource file from the classpath and writes it to the specified path.
-     *
-     * @param stream The {@link InputStream} of a resource file to extract.
-     * @param path     The path where the extracted file will be written.
-     * @return A CompletableFuture representing the completion of the file extraction process.
-     */
-    public CompletableFuture<File> extractResource(InputStream stream, Path path) {
-        CompletableFuture<File> future = new CompletableFuture<>();
-        worker.submit(() -> {
-            try {
-                if (stream == null) {
-                    throw new IllegalStateException("The InputStream is null!");
-                }
-                OutputStream outputStream = new FileOutputStream(path.toFile());
-                byte[] buffer = new byte[1024];
-                int length;
-                while ((length = stream.read(buffer)) > 0) outputStream.write(buffer, 0, length);
-                outputStream.close();
-                stream.close();
-                future.complete(path.toFile());
-            } catch (IOException e) {
-                Logger.error("An error occured whilst extracting a resource", e);
-                future.completeExceptionally(e);
-            }
-        });
-        return future;
+            OutputStream outputStream = new FileOutputStream(path.toFile());
+            byte[] buffer = new byte[1024];
+            int length;
+            while ((length = stream.read(buffer)) > 0) outputStream.write(buffer, 0, length);
+            outputStream.close();
+            stream.close();
+        } catch (IOException e) {
+            Logger.error("An error occured whilst extracting the resource \"" + resource + "\"!", e);
+        }
+        return path.toFile();
     }
 
     private void parseToml(TomlParseResult toml) {

--- a/src/main/java/net/cytonic/cytosis/logging/BootstrapLogger.java
+++ b/src/main/java/net/cytonic/cytosis/logging/BootstrapLogger.java
@@ -1,0 +1,71 @@
+package net.cytonic.cytosis.logging;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.InvocationTargetException;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.logging.*;
+import java.util.logging.Logger;
+
+/**
+ * The logging implementation intended for use with the bootstrapper
+ */
+public class BootstrapLogger {
+    private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss");
+    private static final Logger LOGGER = Logger.getLogger("CytosisBootstrapper");
+
+    static {
+
+        LOGGER.setUseParentHandlers(false);
+
+        Handler consoleHandler = new ConsoleHandler();
+        consoleHandler.setFormatter(new Formatter() {
+            @Override
+            public String format(LogRecord record) {
+                String time = LocalTime.now().format(TIME_FORMAT);
+                StringBuilder sb = new StringBuilder();
+                sb.append(String.format("[%s] [%s] [Bootstrapper] -> %s%n", time, colorizeLevel(record.getLevel()), record.getMessage()));
+                if (record.getThrown() != null) {
+                    StringWriter sw = new StringWriter();
+                    PrintWriter pw = new PrintWriter(sw);
+                    record.getThrown().printStackTrace(pw);
+                    sb.append(sw);
+                }
+                return sb.toString();
+            }
+        });
+        LOGGER.addHandler(consoleHandler);
+    }
+
+    public static void info(String message, Object... args) {
+        LOGGER.log(Level.INFO, message, args);
+    }
+
+    public static void error(String message, Object... args) {
+        LOGGER.log(Level.SEVERE, message, args);
+    }
+
+    public static void warn(String message, Object... args) {
+        LOGGER.log(Level.WARNING, message, args);
+    }
+
+    public static void error(String message, Throwable t) {
+        if (t instanceof InvocationTargetException target) {
+            t = target.getCause();
+        }
+        LOGGER.log(Level.SEVERE, message, t);
+    }
+
+    private static String colorizeLevel(Level level) {
+        String color = switch (level.getName()) {
+            case "SEVERE" -> "\u001B[31m"; // Red
+            case "WARNING" -> "\u001B[33m"; // Yellow
+            case "INFO" -> "\u001B[32m"; // Green
+            case "CONFIG", "FINE" -> "\u001B[36m"; // Cyan
+            case "FINER", "FINEST" -> "\u001B[34m"; // Blue
+            default -> "\u001B[0m"; // Reset
+        };
+        return color + level.getName() + "\u001B[0m";
+    }
+}

--- a/src/main/java/net/cytonic/cytosis/managers/CommandDisablingManager.java
+++ b/src/main/java/net/cytonic/cytosis/managers/CommandDisablingManager.java
@@ -102,7 +102,7 @@ public class CommandDisablingManager {
             for (String cmd : cmds) {
                 CytosisCommand command = parseCommand(cmd);
                 if (command != null) {
-                    Logger.debug("Disabling command: " + cmd);
+                    Logger.info("Disabling command: " + cmd);
                     command.setDisabled(true);
                 } else {
                     Logger.warn("Failed to disable command: " + cmd);

--- a/src/main/java/net/cytonic/cytosis/messaging/nats/NatsManager.java
+++ b/src/main/java/net/cytonic/cytosis/messaging/nats/NatsManager.java
@@ -93,7 +93,7 @@ public class NatsManager {
                     listenForChatMessage();
                 }
             } else {
-                Logger.info("Disconnected from NATS server!");
+                Logger.info("Disconnected from NATS server! ({})", type.name());
                 connection = null;
             }
         };
@@ -535,7 +535,6 @@ public class NatsManager {
 
             ServerSendReponse reponse = ServerSendReponse.parse(message.getData());
 
-            Logger.debug("Sent " + reponse.message() + " to " + player);
             if (!reponse.success()) {
                 p.sendMessage(Msg.serverError("An error occured whilst sending you to %s! <red>(%s)</red>", displayname == null ? "the a server" : displayname, reponse.message()));
             } else {

--- a/src/main/java/net/cytonic/cytosis/messaging/nats/NatsManager.java
+++ b/src/main/java/net/cytonic/cytosis/messaging/nats/NatsManager.java
@@ -496,10 +496,10 @@ public class NatsManager {
                 p.sendMessage(Msg.serverError("An error occured whilst sending you to %s!", server.id()));
             }
 
-            ServerSendReponse reponse = ServerSendReponse.parse(message.getData());
+            ServerSendReponse response = ServerSendReponse.parse(message.getData());
 
-            if (!reponse.success()) {
-                p.sendMessage(Msg.serverError("An error occured whilst sending you to %s! <red>(%s)</red>", server.id(), reponse.message()));
+            if (!response.success()) {
+                p.sendMessage(Msg.serverError("An error occured whilst sending you to %s! <red>(%s)</red>", server.id(), response.message()));
             } else {
                 p.sendMessage(Msg.mm("<yellow><b>NETWORK!</b></yellow><gray> Sending you to %s!", server.id()));
             }
@@ -514,17 +514,17 @@ public class NatsManager {
                 p.sendMessage(Msg.serverError("An error occured whilst sending you to %s!", serverID));
             }
 
-            ServerSendReponse reponse = ServerSendReponse.parse(message.getData());
+            ServerSendReponse response = ServerSendReponse.parse(message.getData());
 
-            if (!reponse.success()) {
-                p.sendMessage(Msg.serverError("An error occured whilst sending you to %s! <red>(%s)</red>", serverID, reponse.message()));
+            if (!response.success()) {
+                p.sendMessage(Msg.serverError("An error occured whilst sending you to %s! <red>(%s)</red>", serverID, response.message()));
             } else {
                 p.sendMessage(Msg.mm("<yellow><b>NETWORK!</b></yellow><gray> Sending you to %s!", serverID));
             }
         }));
     }
 
-    public void sendPlayerToServer(UUID player, String group, String id, @Nullable String displayname) {
+    public void sendPlayerToGenericServer(UUID player, String group, String id, @Nullable String displayname) {
         Thread.ofVirtual().name("NATS Player Sender").start(() -> request(Subjects.PLAYER_SEND_GENERIC, new SendToServerTypeContainer(player, group, id).serialize(), (message, throwable) -> {
             if (Cytosis.getPlayer(player).isEmpty()) return;
             Player p = Cytosis.getPlayer(player).get();
@@ -533,10 +533,10 @@ public class NatsManager {
                 Logger.error("An error occured whilst sending " + player + " to a generic " + group + ":" + id + "! <red>(%s)</red>", throwable);
             }
 
-            ServerSendReponse reponse = ServerSendReponse.parse(message.getData());
+            ServerSendReponse response = ServerSendReponse.parse(message.getData());
 
-            if (!reponse.success()) {
-                p.sendMessage(Msg.serverError("An error occured whilst sending you to %s! <red>(%s)</red>", displayname == null ? "the a server" : displayname, reponse.message()));
+            if (!response.success()) {
+                p.sendMessage(Msg.serverError("An error occured whilst sending you to %s! <red>(%s)</red>", displayname == null ? "the a server" : displayname, response.message()));
             } else {
                 p.sendMessage(Msg.mm("<yellow><b>NETWORK!</b></yellow><gray> Sending you to %s!", displayname == null ? "the a server" : displayname));
             }

--- a/src/main/java/net/cytonic/cytosis/metrics/CytosisOpenTelemetry.java
+++ b/src/main/java/net/cytonic/cytosis/metrics/CytosisOpenTelemetry.java
@@ -15,7 +15,6 @@ import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import net.cytonic.cytosis.Cytosis;
-import net.cytonic.cytosis.logging.Logger;
 
 
 public class CytosisOpenTelemetry {
@@ -73,7 +72,6 @@ public class CytosisOpenTelemetry {
     }
 
     private static String getUrl() {
-        Logger.debug("Debugging URL!");
         // these get read directly from env as the file manager isn't started yet.
         String OPEN_TELEMETRY_HOST = null;
         int OPEN_TELEMETRY_PORT = -1;

--- a/src/main/java/net/cytonic/cytosis/utils/BlockPlacementUtils.java
+++ b/src/main/java/net/cytonic/cytosis/utils/BlockPlacementUtils.java
@@ -1,6 +1,5 @@
 package net.cytonic.cytosis.utils;
 
-import net.cytonic.cytosis.logging.Logger;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.instance.block.Block;
@@ -416,8 +415,6 @@ public class BlockPlacementUtils {
                 double y = state.cursorPosition().y();
 //                boolean up = y == 0.0 ^ !(y == 1.0) || y > 0.5;
                 boolean up = (y == 0.0 || y > 0.5) && y != 1.0;
-
-                Logger.debug("" + state.cursorPosition());
 
                 return blockUpdate(new UpdateState(
                         state.instance(),


### PR DESCRIPTION
This feature adds a bootstrapper that can handle downloading dependencies at runtime. It relies on a nifty gradle task that packages a manifest into the jars which it then reads at run time. This feature also reworks the startup logic, ditching future hell for just blocking the thread. There are 2 gradle tasks it now provides, thinJar makes a light (~800kb) jar that will download dependencies at runtime. It is ideal for development for us to ship builds around to eachother. Then there is fatJar that produces a jar with everything bundled in, like for a docker container. That jar is about 66mb.