### PR TITLE
+ moved the registerCytosisCommands method to be after all components…

### DIFF
--- a/src/main/java/net/cytonic/cytosis/CytosisBootstrap.java
+++ b/src/main/java/net/cytonic/cytosis/CytosisBootstrap.java
@@ -3,6 +3,7 @@ package net.cytonic.cytosis;
 import java.time.Duration;
 import java.util.List;
 
+import net.cytonic.cytosis.commands.utils.CommandHandler;
 import net.minestom.server.Auth;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.command.CommandManager;
@@ -50,6 +51,8 @@ public class CytosisBootstrap {
         applySystemSettings();
         initMinestom();
         BootstrapRegistrationUtils.registerCytosisComponents(cytosisContext);
+        // register commands after every component is registered to avoid missing dependencies
+        cytosisContext.getComponent(CommandHandler.class).registerCytosisCommands();
         initWorld();
 
         Logger.info("Initializing view registry");

--- a/src/main/java/net/cytonic/cytosis/commands/utils/CommandHandler.java
+++ b/src/main/java/net/cytonic/cytosis/commands/utils/CommandHandler.java
@@ -69,7 +69,6 @@ public class CommandHandler implements Bootstrappable {
     @Override
     public void init() {
         this.commandManager = Cytosis.CONTEXT.getComponent(CommandManager.class);
-        registerCytosisCommands();
     }
 
     /**


### PR DESCRIPTION
This is to avoid any other issues with commands not having required dependencies initiated. This should allow for all the components to be registered properly before registering the commands.