### PR TITLE
Feat: particle engine improvements

### DIFF
--- a/src/main/java/net/cytonic/cytosis/commands/debug/particles/BezierCommand.java
+++ b/src/main/java/net/cytonic/cytosis/commands/debug/particles/BezierCommand.java
@@ -9,21 +9,28 @@ import net.cytonic.cytosis.particles.effects.keyframed.BezierCurveEffect;
 import net.cytonic.cytosis.particles.effects.keyframed.BridgingStrategy;
 import net.cytonic.cytosis.particles.effects.keyframed.EasingFunction;
 import net.cytonic.cytosis.particles.util.ParticleData;
+import net.cytonic.cytosis.player.CytosisPlayer;
 
 public class BezierCommand extends CytosisCommand {
 
     public BezierCommand() {
         super("bezier");
         setDefaultExecutor((sender, ignored) -> {
+            if (!(sender instanceof CytosisPlayer player)) return;
+            ParticleEngine engine = player.getInstance().getTag(ParticleEngine.TAG);
+            if (engine == null) {
+                player.whoops("Your instance does not have a particle engine!");
+                return;
+            }
             BezierCurveEffect bezierCurveEffect = new BezierCurveEffect(100, 20, EasingFunction.EXPONENTIAL, 200,
                 BridgingStrategy.line(10), () -> ParticleData.simple(Particle.FLAME), new Pos(-5, 120, 0),
                 new Pos(0, 130, 0), new Pos(5, 120, 0));
-            ParticleEngine.playKeyframed(bezierCurveEffect);
+            engine.playKeyframed(bezierCurveEffect);
 
             BezierCurveEffect bezierCurveEffect2 = new BezierCurveEffect(100, 20, EasingFunction.LINEAR, 200,
                 BridgingStrategy.line(10), () -> ParticleData.simple(Particle.FLAME), new Pos(-5, 125, 0),
                 new Pos(0, 135, 0), new Pos(5, 125, 0));
-            ParticleEngine.playKeyframed(bezierCurveEffect2);
+            engine.playKeyframed(bezierCurveEffect2);
         });
     }
 }

--- a/src/main/java/net/cytonic/cytosis/commands/debug/particles/CircleCommand.java
+++ b/src/main/java/net/cytonic/cytosis/commands/debug/particles/CircleCommand.java
@@ -18,6 +18,11 @@ public class CircleCommand extends CytosisCommand {
         super("circle");
         setDefaultExecutor((sender, ignored) -> {
             if (!(sender instanceof CytosisPlayer p)) return;
+            ParticleEngine engine = p.getInstance().getTag(ParticleEngine.TAG);
+            if (engine == null) {
+                p.whoops("Your instance does not have a particle engine!");
+                return;
+            }
             CircularLoopingEffect c1 = new CircularLoopingEffect(p::getPosition, 16, Phase.TWO,
                 _ -> new Vec(0, 2.5, 0), _ -> .7, () -> ParticleData.simple(Particle.TOTEM_OF_UNDYING),
                 BridgingStrategy.midpoint(), 0);
@@ -30,10 +35,10 @@ public class CircleCommand extends CytosisCommand {
             CircularLoopingEffect c4 = new CircularLoopingEffect(p::getPosition, 16, Phase.FOUR,
                 _ -> new Vec(0, 2.5, 0), _ -> .7, () -> ParticleData.simple(Particle.TOTEM_OF_UNDYING),
                 BridgingStrategy.midpoint(), 0);
-            ParticleEngine.playLooping(c1, 100);
-            ParticleEngine.playLooping(c2, 100);
-            ParticleEngine.playLooping(c3, 100);
-            ParticleEngine.playLooping(c4, 100);
+            engine.playLooping(c1, 100);
+            engine.playLooping(c2, 100);
+            engine.playLooping(c3, 100);
+            engine.playLooping(c4, 100);
         });
     }
 }

--- a/src/main/java/net/cytonic/cytosis/commands/debug/particles/CircleCommand.java
+++ b/src/main/java/net/cytonic/cytosis/commands/debug/particles/CircleCommand.java
@@ -2,7 +2,6 @@ package net.cytonic.cytosis.commands.debug.particles;
 
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.particle.Particle;
-import net.minestom.server.timer.TaskSchedule;
 
 import net.cytonic.cytosis.commands.utils.CytosisCommand;
 import net.cytonic.cytosis.particles.ParticleEngine;
@@ -20,21 +19,21 @@ public class CircleCommand extends CytosisCommand {
         setDefaultExecutor((sender, ignored) -> {
             if (!(sender instanceof CytosisPlayer p)) return;
             CircularLoopingEffect c1 = new CircularLoopingEffect(p::getPosition, 16, Phase.TWO,
-                angle -> new Vec(0, 2.5, 0), rot -> .7, () -> ParticleData.simple(Particle.TOTEM_OF_UNDYING),
+                _ -> new Vec(0, 2.5, 0), _ -> .7, () -> ParticleData.simple(Particle.TOTEM_OF_UNDYING),
                 BridgingStrategy.midpoint(), 0);
             CircularLoopingEffect c2 = new CircularLoopingEffect(p::getPosition, 16, Phase.FOUR,
-                angle -> new Vec(0, 2.5, 0), rot -> .7, () -> ParticleData.simple(Particle.TOTEM_OF_UNDYING),
+                _ -> new Vec(0, 2.5, 0), _ -> .7, () -> ParticleData.simple(Particle.TOTEM_OF_UNDYING),
                 BridgingStrategy.midpoint(), Angles.NINETY);
             CircularLoopingEffect c3 = new CircularLoopingEffect(p::getPosition, 16, Phase.TWO,
-                angle -> new Vec(0, 2.5, 0), rot -> .7, () -> ParticleData.simple(Particle.TOTEM_OF_UNDYING),
+                _ -> new Vec(0, 2.5, 0), _ -> .7, () -> ParticleData.simple(Particle.TOTEM_OF_UNDYING),
                 BridgingStrategy.midpoint(), Angles.NINETY);
             CircularLoopingEffect c4 = new CircularLoopingEffect(p::getPosition, 16, Phase.FOUR,
-                angle -> new Vec(0, 2.5, 0), rot -> .7, () -> ParticleData.simple(Particle.TOTEM_OF_UNDYING),
+                _ -> new Vec(0, 2.5, 0), _ -> .7, () -> ParticleData.simple(Particle.TOTEM_OF_UNDYING),
                 BridgingStrategy.midpoint(), 0);
-            ParticleEngine.playLooping(c1, TaskSchedule.tick(3));
-            ParticleEngine.playLooping(c2, TaskSchedule.tick(3));
-            ParticleEngine.playLooping(c3, TaskSchedule.tick(3));
-            ParticleEngine.playLooping(c4, TaskSchedule.tick(3));
+            ParticleEngine.playLooping(c1, 100);
+            ParticleEngine.playLooping(c2, 100);
+            ParticleEngine.playLooping(c3, 100);
+            ParticleEngine.playLooping(c4, 100);
         });
     }
 }

--- a/src/main/java/net/cytonic/cytosis/commands/debug/particles/CreateEngineCommand.java
+++ b/src/main/java/net/cytonic/cytosis/commands/debug/particles/CreateEngineCommand.java
@@ -1,0 +1,21 @@
+package net.cytonic.cytosis.commands.debug.particles;
+
+import net.cytonic.cytosis.commands.utils.CytosisCommand;
+import net.cytonic.cytosis.particles.ParticleEngine;
+import net.cytonic.cytosis.player.CytosisPlayer;
+
+class CreateEngineCommand extends CytosisCommand {
+
+    CreateEngineCommand() {
+        super("createengine");
+        setDefaultExecutor((sender, _) -> {
+            if (!(sender instanceof CytosisPlayer player)) return;
+            if (player.getInstance().hasTag(ParticleEngine.TAG)) {
+                player.whoops("Your instance already has a Particle Engine!");
+                return;
+            }
+            player.getInstance().setTag(ParticleEngine.TAG, new ParticleEngine(player.getInstance()));
+            player.success("A particle engine has been created for your instance!");
+        });
+    }
+}

--- a/src/main/java/net/cytonic/cytosis/commands/debug/particles/ParticleCommand.java
+++ b/src/main/java/net/cytonic/cytosis/commands/debug/particles/ParticleCommand.java
@@ -13,5 +13,6 @@ public class ParticleCommand extends CytosisCommand {
         addSubcommand(new BezierCommand());
         addSubcommand(new PatternedCommand());
         addSubcommand(new CircleCommand());
+        addSubcommand(new CreateEngineCommand());
     }
 }

--- a/src/main/java/net/cytonic/cytosis/commands/debug/particles/PatternedCommand.java
+++ b/src/main/java/net/cytonic/cytosis/commands/debug/particles/PatternedCommand.java
@@ -2,19 +2,25 @@ package net.cytonic.cytosis.commands.debug.particles;
 
 import java.util.Map;
 
-import net.minestom.server.coordinate.Pos;
 import net.minestom.server.particle.Particle;
 
 import net.cytonic.cytosis.commands.utils.CytosisCommand;
 import net.cytonic.cytosis.particles.ParticleEngine;
 import net.cytonic.cytosis.particles.effects.fixed.PatternedEffect;
 import net.cytonic.cytosis.particles.util.ParticleData;
+import net.cytonic.cytosis.player.CytosisPlayer;
 
 public class PatternedCommand extends CytosisCommand {
 
     public PatternedCommand() {
         super("patterned");
         setDefaultExecutor((sender, ignored) -> {
+            if (!(sender instanceof CytosisPlayer player)) return;
+            ParticleEngine engine = player.getInstance().getTag(ParticleEngine.TAG);
+            if (engine == null) {
+                player.whoops("Your instance does not have a particle engine!");
+                return;
+            }
             PatternedEffect patterned1 = new PatternedEffect(.2, .2,
                 new char[][]{new char[]{' ', ' ', ' ', ' ', ' ', ' ', ' '},
                     new char[]{' ', 'X', ' ', 'X', ' ', '#', ' '}, new char[]{' ', '#', ' ', 'X', ' ', ' ', ' '},
@@ -22,8 +28,9 @@ public class PatternedCommand extends CytosisCommand {
                     new char[]{' ', '#', ' ', 'X', ' ', '#', ' '}, new char[]{' ', ' ', ' ', ' ', ' ', ' ', ' '},
                 },
                 Map.of('X', () -> ParticleData.simple(Particle.END_ROD), '#',
-                    () -> ParticleData.simple(Particle.FLAME)), new Pos(44, 88, -31));
-            ParticleEngine.playStatic(patterned1);
+                    () -> ParticleData.simple(Particle.FLAME)),
+                player.getPosition().direction().normalize().mul(5).add(player.getPosition()).asPos());
+            engine.playStatic(patterned1);
         });
     }
 }

--- a/src/main/java/net/cytonic/cytosis/particles/ParticleAudience.java
+++ b/src/main/java/net/cytonic/cytosis/particles/ParticleAudience.java
@@ -58,7 +58,7 @@ public class ParticleAudience implements PacketGroupingAudience {
     public void sendGroupedPacket(@NonNull ServerPacket packet) {
         if (!(packet instanceof ParticlePacket p))
             throw new IllegalArgumentException("Particle audiences should only be used for Particle Packets.");
-        ParticleSendEvent e = new ParticleSendEvent(p, players);
+        ParticleSendEvent e = new ParticleSendEvent(p, instance, players);
         EventDispatcher.callCancellable(e, () -> PacketGroupingAudience.super.sendGroupedPacket(packet));
     }
 }

--- a/src/main/java/net/cytonic/cytosis/particles/ParticleAudience.java
+++ b/src/main/java/net/cytonic/cytosis/particles/ParticleAudience.java
@@ -1,0 +1,64 @@
+package net.cytonic.cytosis.particles;
+
+import java.util.Collection;
+import java.util.Set;
+
+import lombok.AllArgsConstructor;
+import net.minestom.server.adventure.audience.PacketGroupingAudience;
+import net.minestom.server.entity.Player;
+import net.minestom.server.event.EventDispatcher;
+import net.minestom.server.instance.Instance;
+import net.minestom.server.network.packet.server.ServerPacket;
+import net.minestom.server.network.packet.server.play.ParticlePacket;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+
+import net.cytonic.cytosis.player.CytosisPlayer;
+
+@AllArgsConstructor
+public class ParticleAudience implements PacketGroupingAudience {
+
+    @Nullable
+    private final Set<CytosisPlayer> players;
+    Instance instance;
+
+    /**
+     * A single player audience
+     */
+    public static ParticleAudience singleton(CytosisPlayer player) {
+        return new ParticleAudience(Set.of(player), player.getInstance());
+    }
+
+    /**
+     * A static particle audience of the given players
+     */
+    public static ParticleAudience of(CytosisPlayer... players) {
+        if (players.length < 1)
+            throw new IllegalArgumentException("There must be at least one player in a ParticleAudience");
+        return new ParticleAudience(Set.of(players), players[0].getInstance());
+    }
+
+    /**
+     * A dynamic audience which send packets to all players of an instance. Each time a packet is sent, the player
+     * recipient set is refreshed.
+     */
+    public static ParticleAudience of(Instance instance) {
+        return new ParticleAudience(null, instance);
+    }
+
+    @Override
+    @NotNull
+    public Collection<? extends Player> getPlayers() {
+        if (players == null) return instance.getPlayers();
+        return players;
+    }
+
+    @Override
+    public void sendGroupedPacket(@NonNull ServerPacket packet) {
+        if (!(packet instanceof ParticlePacket p))
+            throw new IllegalArgumentException("Particle audiences should only be used for Particle Packets.");
+        ParticleSendEvent e = new ParticleSendEvent(p, players);
+        EventDispatcher.callCancellable(e, () -> PacketGroupingAudience.super.sendGroupedPacket(packet));
+    }
+}

--- a/src/main/java/net/cytonic/cytosis/particles/ParticleEffect.java
+++ b/src/main/java/net/cytonic/cytosis/particles/ParticleEffect.java
@@ -2,7 +2,6 @@ package net.cytonic.cytosis.particles;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import net.minestom.server.adventure.audience.PacketGroupingAudience;
 import org.jetbrains.annotations.ApiStatus;
 
 @AllArgsConstructor
@@ -12,5 +11,5 @@ public abstract class ParticleEffect {
     final ParticleEffectType type;
 
     @ApiStatus.Internal
-    public abstract void play(PacketGroupingAudience audience);
+    public abstract void play(ParticleAudience audience);
 }

--- a/src/main/java/net/cytonic/cytosis/particles/ParticleEngine.java
+++ b/src/main/java/net/cytonic/cytosis/particles/ParticleEngine.java
@@ -1,12 +1,13 @@
 package net.cytonic.cytosis.particles;
 
 import java.util.ArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
-import net.minestom.server.MinecraftServer;
 import net.minestom.server.adventure.audience.PacketGroupingAudience;
-import net.minestom.server.timer.SchedulerManager;
-import net.minestom.server.timer.Task;
-import net.minestom.server.timer.TaskSchedule;
+import org.jetbrains.annotations.ApiStatus.Internal;
 
 import net.cytonic.cytosis.Cytosis;
 import net.cytonic.cytosis.particles.effects.fixed.StaticEffect;
@@ -18,7 +19,8 @@ import net.cytonic.cytosis.particles.effects.looping.LoopingEffect;
  */
 public class ParticleEngine {
 
-    private static final SchedulerManager SCHEDULER = MinecraftServer.getSchedulerManager();
+    public static final int THREAD_POOL_SIZE = 1;
+    private static final ScheduledExecutorService SCHEDULER = Executors.newScheduledThreadPool(THREAD_POOL_SIZE);
 
     /**
      * Plays this keyframed effect for every Cytosis player. For more fined grained control over who the effect is
@@ -46,42 +48,38 @@ public class ParticleEngine {
      * {@link #playKeyframed(KeyframedEffect)}
      *
      * @param effect the keyframed effect to play
-     * @param delay  the delay in ticks before the effect starts playing
+     * @param delay  the delay in milliseconds before the effect starts playing
      */
     public static void playKeyframed(PacketGroupingAudience audience, KeyframedEffect effect, int delay) {
         if (delay == 0) {
-            playKeyFramedInteral(audience, effect);
+            playKeyFramedInternal(audience, effect);
             return;
         }
-        SCHEDULER.buildTask(() -> playKeyFramedInteral(audience, effect)).delay(TaskSchedule.tick(delay)).schedule();
+        SCHEDULER.schedule(() -> playKeyFramedInternal(audience, effect), delay, TimeUnit.MILLISECONDS);
     }
 
-    private static void playKeyFramedInteral(PacketGroupingAudience audience, KeyframedEffect effect) {
+    @Internal
+    private static void playKeyFramedInternal(PacketGroupingAudience audience, KeyframedEffect effect) {
         effect.getKeyframeEffects().forEach((time, effectsToPlay) -> {
             if (time <= 0) {
                 effectsToPlay.forEach(eff -> eff.play(audience));
                 return;
             }
-            SCHEDULER.buildTask(() -> effectsToPlay.forEach(eff -> eff.play(audience)))
-                .delay(TaskSchedule.tick(time)).schedule();
+            SCHEDULER.schedule(() -> effectsToPlay.forEach(eff -> eff.play(audience)), time, TimeUnit.MILLISECONDS);
         });
     }
 
-    public static Task playLooping(LoopingEffect effect, TaskSchedule period) {
+    public static ScheduledFuture<?> playLooping(LoopingEffect effect, int period) {
         return playLooping(effect, period, PacketGroupingAudience.of(new ArrayList<>(Cytosis.getOnlinePlayers())));
     }
 
-    public static Task playLooping(LoopingEffect effect, TaskSchedule period, PacketGroupingAudience audience) {
+    public static ScheduledFuture<?> playLooping(LoopingEffect effect, int period, PacketGroupingAudience audience) {
         return playLooping(effect, period, audience, 0);
     }
 
-    public static Task playLooping(LoopingEffect effect, TaskSchedule period, PacketGroupingAudience audience,
+    public static ScheduledFuture<?> playLooping(LoopingEffect effect, int period, PacketGroupingAudience audience,
         int delay) {
-        if (delay == 0) {
-            return SCHEDULER.buildTask(() -> effect.playNextTick(audience)).repeat(period).schedule();
-        }
-        return SCHEDULER.buildTask(() -> effect.playNextTick(audience)).repeat(period).delay(TaskSchedule.tick(delay))
-            .schedule();
+        return SCHEDULER.scheduleAtFixedRate(() -> effect.playNextTick(audience), delay, period, TimeUnit.MILLISECONDS);
     }
 
     public static void playStatic(StaticEffect effect) {
@@ -97,6 +95,6 @@ public class ParticleEngine {
             effect.play(audience);
             return;
         }
-        SCHEDULER.buildTask(() -> effect.play(audience)).delay(TaskSchedule.tick(delay)).schedule();
+        SCHEDULER.schedule(() -> effect.play(audience), delay, TimeUnit.MILLISECONDS);
     }
 }

--- a/src/main/java/net/cytonic/cytosis/particles/ParticleEngine.java
+++ b/src/main/java/net/cytonic/cytosis/particles/ParticleEngine.java
@@ -1,15 +1,15 @@
 package net.cytonic.cytosis.particles;
 
-import java.util.ArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import net.minestom.server.adventure.audience.PacketGroupingAudience;
+import lombok.AllArgsConstructor;
+import net.minestom.server.instance.Instance;
+import net.minestom.server.tag.Tag;
 import org.jetbrains.annotations.ApiStatus.Internal;
 
-import net.cytonic.cytosis.Cytosis;
 import net.cytonic.cytosis.particles.effects.fixed.StaticEffect;
 import net.cytonic.cytosis.particles.effects.keyframed.KeyframedEffect;
 import net.cytonic.cytosis.particles.effects.looping.LoopingEffect;
@@ -17,40 +17,46 @@ import net.cytonic.cytosis.particles.effects.looping.LoopingEffect;
 /**
  * The class that handles all the interactions with the particle api. It's the primary entrypoint.
  */
+@AllArgsConstructor
 public class ParticleEngine {
 
+    public static final Tag<ParticleEngine> TAG = Tag.Transient("cytosis:particle-engine");
     public static final int THREAD_POOL_SIZE = 1;
-    private static final ScheduledExecutorService SCHEDULER = Executors.newScheduledThreadPool(THREAD_POOL_SIZE);
+    private final Instance instance;
+    private final ScheduledExecutorService SCHEDULER = Executors.newScheduledThreadPool(THREAD_POOL_SIZE);
 
-    /**
-     * Plays this keyframed effect for every Cytosis player. For more fined grained control over who the effect is
-     * played for, use {@link #playKeyframed(PacketGroupingAudience, KeyframedEffect)}
-     *
-     * @param effect the keyframed effect to play
-     */
-    public static void playKeyframed(KeyframedEffect effect) {
-        PacketGroupingAudience audience = PacketGroupingAudience.of(new ArrayList<>(Cytosis.getOnlinePlayers()));
-        playKeyframed(audience, effect);
+    private ParticleAudience getAudience() {
+        return ParticleAudience.of(instance);
     }
 
     /**
-     * Plays this keyframed effect for every player in the audience. To play this for everyone, use
+     * Plays this keyframed effect for every Cytosis player on this instance. For more fined grained control over whom
+     * the effect is played for, use {@link #playKeyframed(ParticleAudience, KeyframedEffect)}
+     *
+     * @param effect the keyframed effect to play
+     */
+    public void playKeyframed(KeyframedEffect effect) {
+        playKeyframed(getAudience(), effect);
+    }
+
+    /**
+     * Plays this keyframed effect for every player in the instance. To play this for everyone, use
      * {@link #playKeyframed(KeyframedEffect)}
      *
      * @param effect the keyframed effect to play
      */
-    public static void playKeyframed(PacketGroupingAudience audience, KeyframedEffect effect) {
+    public void playKeyframed(ParticleAudience audience, KeyframedEffect effect) {
         playKeyframed(audience, effect, 0);
     }
 
     /**
-     * Plays this keyframed effect for every player in the audience. To play this for everyone, use
+     * Plays this keyframed effect for every player in the instance. To play this for everyone, use
      * {@link #playKeyframed(KeyframedEffect)}
      *
      * @param effect the keyframed effect to play
      * @param delay  the delay in milliseconds before the effect starts playing
      */
-    public static void playKeyframed(PacketGroupingAudience audience, KeyframedEffect effect, int delay) {
+    public void playKeyframed(ParticleAudience audience, KeyframedEffect effect, int delay) {
         if (delay == 0) {
             playKeyFramedInternal(audience, effect);
             return;
@@ -59,7 +65,7 @@ public class ParticleEngine {
     }
 
     @Internal
-    private static void playKeyFramedInternal(PacketGroupingAudience audience, KeyframedEffect effect) {
+    private void playKeyFramedInternal(ParticleAudience audience, KeyframedEffect effect) {
         effect.getKeyframeEffects().forEach((time, effectsToPlay) -> {
             if (time <= 0) {
                 effectsToPlay.forEach(eff -> eff.play(audience));
@@ -69,28 +75,29 @@ public class ParticleEngine {
         });
     }
 
-    public static ScheduledFuture<?> playLooping(LoopingEffect effect, int period) {
-        return playLooping(effect, period, PacketGroupingAudience.of(new ArrayList<>(Cytosis.getOnlinePlayers())));
+    public ScheduledFuture<?> playLooping(LoopingEffect effect, int period) {
+        return playLooping(effect, period, getAudience());
     }
 
-    public static ScheduledFuture<?> playLooping(LoopingEffect effect, int period, PacketGroupingAudience audience) {
+    public ScheduledFuture<?> playLooping(LoopingEffect effect, int period, ParticleAudience audience) {
         return playLooping(effect, period, audience, 0);
     }
 
-    public static ScheduledFuture<?> playLooping(LoopingEffect effect, int period, PacketGroupingAudience audience,
+    public ScheduledFuture<?> playLooping(LoopingEffect effect, int period, ParticleAudience audience,
         int delay) {
-        return SCHEDULER.scheduleAtFixedRate(() -> effect.playNextTick(audience), delay, period, TimeUnit.MILLISECONDS);
+        return SCHEDULER.scheduleAtFixedRate(() -> effect.playNextTick(audience, this), delay, period,
+            TimeUnit.MILLISECONDS);
     }
 
-    public static void playStatic(StaticEffect effect) {
-        playStatic(effect, PacketGroupingAudience.of(new ArrayList<>(Cytosis.getOnlinePlayers())));
+    public void playStatic(StaticEffect effect) {
+        playStatic(effect, getAudience());
     }
 
-    public static void playStatic(StaticEffect effect, PacketGroupingAudience audience) {
+    public void playStatic(StaticEffect effect, ParticleAudience audience) {
         playStatic(effect, audience, 0);
     }
 
-    public static void playStatic(StaticEffect effect, PacketGroupingAudience audience, int delay) {
+    public void playStatic(StaticEffect effect, ParticleAudience audience, int delay) {
         if (delay == 0) {
             effect.play(audience);
             return;

--- a/src/main/java/net/cytonic/cytosis/particles/ParticleSendEvent.java
+++ b/src/main/java/net/cytonic/cytosis/particles/ParticleSendEvent.java
@@ -9,7 +9,10 @@ import lombok.Setter;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.event.trait.CancellableEvent;
+import net.minestom.server.event.trait.InstanceEvent;
+import net.minestom.server.instance.Instance;
 import net.minestom.server.network.packet.server.play.ParticlePacket;
+import org.jetbrains.annotations.ApiStatus.Internal;
 import org.jetbrains.annotations.Nullable;
 
 import net.cytonic.cytosis.particles.util.ParticleData;
@@ -17,7 +20,7 @@ import net.cytonic.cytosis.player.CytosisPlayer;
 
 @Getter
 @Setter
-public class ParticleSendEvent implements CancellableEvent {
+public class ParticleSendEvent implements CancellableEvent, InstanceEvent {
 
     /**
      * Null means it was sent to the entire instance
@@ -26,19 +29,23 @@ public class ParticleSendEvent implements CancellableEvent {
     private final Set<UUID> recipients;
     private final ParticleData data;
     private final Pos pos;
+    private final Instance instance;
     private boolean cancelled;
 
-    public ParticleSendEvent(ParticleData data, Pos pos, UUID... recipients) {
+    public ParticleSendEvent(ParticleData data, Instance instance, Pos pos, UUID... recipients) {
         this.recipients = Set.of(recipients);
         this.pos = pos;
         this.data = data;
+        this.instance = instance;
     }
 
-    public ParticleSendEvent(ParticlePacket packet, @Nullable Set<CytosisPlayer> recipients) {
+    @Internal
+    public ParticleSendEvent(ParticlePacket packet, Instance i, @Nullable Set<CytosisPlayer> recipients) {
         if (recipients != null) {
             this.recipients = recipients.stream().map(Entity::getUuid).collect(Collectors.toSet());
         } else this.recipients = null;
         this.pos = new Pos(packet.x(), packet.y(), packet.z());
         this.data = ParticleData.fromPacket(packet);
+        this.instance = i;
     }
 }

--- a/src/main/java/net/cytonic/cytosis/particles/ParticleSendEvent.java
+++ b/src/main/java/net/cytonic/cytosis/particles/ParticleSendEvent.java
@@ -1,0 +1,44 @@
+package net.cytonic.cytosis.particles;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import lombok.Getter;
+import lombok.Setter;
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.entity.Entity;
+import net.minestom.server.event.trait.CancellableEvent;
+import net.minestom.server.network.packet.server.play.ParticlePacket;
+import org.jetbrains.annotations.Nullable;
+
+import net.cytonic.cytosis.particles.util.ParticleData;
+import net.cytonic.cytosis.player.CytosisPlayer;
+
+@Getter
+@Setter
+public class ParticleSendEvent implements CancellableEvent {
+
+    /**
+     * Null means it was sent to the entire instance
+     */
+    @Nullable
+    private final Set<UUID> recipients;
+    private final ParticleData data;
+    private final Pos pos;
+    private boolean cancelled;
+
+    public ParticleSendEvent(ParticleData data, Pos pos, UUID... recipients) {
+        this.recipients = Set.of(recipients);
+        this.pos = pos;
+        this.data = data;
+    }
+
+    public ParticleSendEvent(ParticlePacket packet, @Nullable Set<CytosisPlayer> recipients) {
+        if (recipients != null) {
+            this.recipients = recipients.stream().map(Entity::getUuid).collect(Collectors.toSet());
+        } else this.recipients = null;
+        this.pos = new Pos(packet.x(), packet.y(), packet.z());
+        this.data = ParticleData.fromPacket(packet);
+    }
+}

--- a/src/main/java/net/cytonic/cytosis/particles/effects/fixed/LineEffect.java
+++ b/src/main/java/net/cytonic/cytosis/particles/effects/fixed/LineEffect.java
@@ -2,10 +2,10 @@ package net.cytonic.cytosis.particles.effects.fixed;
 
 import java.util.List;
 
-import net.minestom.server.adventure.audience.PacketGroupingAudience;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Vec;
 
+import net.cytonic.cytosis.particles.ParticleAudience;
 import net.cytonic.cytosis.particles.util.ParticleSupplier;
 import net.cytonic.cytosis.utils.Utils;
 
@@ -39,7 +39,7 @@ public class LineEffect extends StaticEffect {
     }
 
     @Override
-    public void play(PacketGroupingAudience audience) {
+    public void play(ParticleAudience audience) {
         positions.forEach(p -> audience.sendGroupedPacket(supplier.get().getPacket(p)));
     }
 }

--- a/src/main/java/net/cytonic/cytosis/particles/effects/fixed/PatternedEffect.java
+++ b/src/main/java/net/cytonic/cytosis/particles/effects/fixed/PatternedEffect.java
@@ -5,10 +5,10 @@ import java.util.List;
 import java.util.Map;
 
 import lombok.AllArgsConstructor;
-import net.minestom.server.adventure.audience.PacketGroupingAudience;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.network.packet.server.play.ParticlePacket;
 
+import net.cytonic.cytosis.particles.ParticleAudience;
 import net.cytonic.cytosis.particles.util.ParticleSupplier;
 
 @AllArgsConstructor
@@ -21,7 +21,7 @@ public class PatternedEffect extends StaticEffect {
     private Pos pos;
 
     @Override
-    public void play(PacketGroupingAudience audience) {
+    public void play(ParticleAudience audience) {
         if (pattern.length == 0 || pattern[0].length == 0) {
             throw new IllegalArgumentException("Pattern must be at least 1x1");
         }

--- a/src/main/java/net/cytonic/cytosis/particles/effects/fixed/SingleParticleEffect.java
+++ b/src/main/java/net/cytonic/cytosis/particles/effects/fixed/SingleParticleEffect.java
@@ -1,9 +1,9 @@
 package net.cytonic.cytosis.particles.effects.fixed;
 
 import lombok.AllArgsConstructor;
-import net.minestom.server.adventure.audience.PacketGroupingAudience;
 import net.minestom.server.coordinate.Point;
 
+import net.cytonic.cytosis.particles.ParticleAudience;
 import net.cytonic.cytosis.particles.util.ParticleSupplier;
 
 @AllArgsConstructor
@@ -13,7 +13,7 @@ public class SingleParticleEffect extends StaticEffect {
     private final Point pos;
 
     @Override
-    public void play(PacketGroupingAudience audience) {
+    public void play(ParticleAudience audience) {
         audience.sendGroupedPacket(particle.get().getPacket(pos));
     }
 }

--- a/src/main/java/net/cytonic/cytosis/particles/effects/keyframed/BridgingStrategy.java
+++ b/src/main/java/net/cytonic/cytosis/particles/effects/keyframed/BridgingStrategy.java
@@ -1,10 +1,10 @@
 package net.cytonic.cytosis.particles.effects.keyframed;
 
-import net.minestom.server.adventure.audience.PacketGroupingAudience;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Pos;
 import org.jetbrains.annotations.ApiStatus;
 
+import net.cytonic.cytosis.particles.ParticleAudience;
 import net.cytonic.cytosis.particles.effects.fixed.LineEffect;
 import net.cytonic.cytosis.particles.effects.fixed.SingleParticleEffect;
 import net.cytonic.cytosis.particles.effects.fixed.StaticEffect;
@@ -121,7 +121,7 @@ public interface BridgingStrategy {
         public StaticEffect render(ParticleSupplier supplier, Point start, Point end) {
             return new StaticEffect() {
                 @Override
-                public void play(PacketGroupingAudience audience) {
+                public void play(ParticleAudience audience) {
 
                 }
             }; // an empty effect

--- a/src/main/java/net/cytonic/cytosis/particles/effects/keyframed/KeyframedEffect.java
+++ b/src/main/java/net/cytonic/cytosis/particles/effects/keyframed/KeyframedEffect.java
@@ -5,9 +5,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import net.minestom.server.adventure.audience.PacketGroupingAudience;
-
 import net.cytonic.cytosis.particles.Keyframeable;
+import net.cytonic.cytosis.particles.ParticleAudience;
 import net.cytonic.cytosis.particles.ParticleEffect;
 import net.cytonic.cytosis.particles.ParticleEffectType;
 
@@ -70,7 +69,7 @@ public abstract class KeyframedEffect extends ParticleEffect implements Keyframe
     }
 
     @Override
-    public void play(PacketGroupingAudience audience) {
+    public void play(ParticleAudience audience) {
         throw new UnsupportedOperationException(
             "Keyframed effects cannot be played directly. Use ParticleEngine#playKeyframed(PacketGroupingAudience,"
                 + " KeyframedEffect) instead.");

--- a/src/main/java/net/cytonic/cytosis/particles/effects/looping/CircularLoopingEffect.java
+++ b/src/main/java/net/cytonic/cytosis/particles/effects/looping/CircularLoopingEffect.java
@@ -3,11 +3,12 @@ package net.cytonic.cytosis.particles.effects.looping;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import net.minestom.server.adventure.audience.PacketGroupingAudience;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Pos;
 import org.jetbrains.annotations.ApiStatus;
 
+import net.cytonic.cytosis.particles.ParticleAudience;
+import net.cytonic.cytosis.particles.ParticleEngine;
 import net.cytonic.cytosis.particles.effects.keyframed.BridgingStrategy;
 import net.cytonic.cytosis.particles.util.ParticleSupplier;
 
@@ -114,7 +115,7 @@ public class CircularLoopingEffect extends LoopingEffect {
 
     @Override
     @ApiStatus.Internal
-    public void playNextTick(PacketGroupingAudience audience) {
+    public void playNextTick(ParticleAudience audience, ParticleEngine engine) {
         if (currentTick >= resolution) {
             currentAngle = 0;
             currentTick = 0;

--- a/src/main/java/net/cytonic/cytosis/particles/effects/looping/Emitter.java
+++ b/src/main/java/net/cytonic/cytosis/particles/effects/looping/Emitter.java
@@ -2,9 +2,9 @@ package net.cytonic.cytosis.particles.effects.looping;
 
 import java.util.function.Supplier;
 
-import net.minestom.server.adventure.audience.PacketGroupingAudience;
 import net.minestom.server.coordinate.Point;
 
+import net.cytonic.cytosis.particles.ParticleAudience;
 import net.cytonic.cytosis.particles.ParticleEngine;
 import net.cytonic.cytosis.particles.effects.fixed.SingleParticleEffect;
 import net.cytonic.cytosis.particles.util.ParticleSupplier;
@@ -32,21 +32,21 @@ public class Emitter extends LoopingEffect {
     }
 
     @Override
-    public void playNextTick(PacketGroupingAudience audience) {
+    public void playNextTick(ParticleAudience audience, ParticleEngine engine) {
         currentTick++;
         if (frequency < 1) {
             int interval = (int) Math.round(1 / frequency);
-            if (currentTick % interval == 0) emitParticle(audience);
+            if (currentTick % interval == 0) emitParticle(audience, engine);
         } else {
             accumulator += frequency;
             while (accumulator >= 1) {
-                emitParticle(audience);
+                emitParticle(audience, engine);
                 accumulator -= 1;
             }
         }
     }
 
-    private void emitParticle(PacketGroupingAudience audience) {
-        ParticleEngine.playStatic(new SingleParticleEffect(supplier, getPosSupplier().get()), audience);
+    private void emitParticle(ParticleAudience audience, ParticleEngine engine) {
+        engine.playStatic(new SingleParticleEffect(supplier, getPosSupplier().get()), audience);
     }
 }

--- a/src/main/java/net/cytonic/cytosis/particles/effects/looping/LoopingEffect.java
+++ b/src/main/java/net/cytonic/cytosis/particles/effects/looping/LoopingEffect.java
@@ -3,11 +3,12 @@ package net.cytonic.cytosis.particles.effects.looping;
 import java.util.function.Supplier;
 
 import lombok.Getter;
-import net.minestom.server.adventure.audience.PacketGroupingAudience;
 import net.minestom.server.coordinate.Point;
 
+import net.cytonic.cytosis.particles.ParticleAudience;
 import net.cytonic.cytosis.particles.ParticleEffect;
 import net.cytonic.cytosis.particles.ParticleEffectType;
+import net.cytonic.cytosis.particles.ParticleEngine;
 
 @Getter
 public abstract class LoopingEffect extends ParticleEffect {
@@ -20,11 +21,11 @@ public abstract class LoopingEffect extends ParticleEffect {
     }
 
     @Override
-    public void play(PacketGroupingAudience audience) {
+    public void play(ParticleAudience audience) {
         throw new UnsupportedOperationException(
-            "Looping effects cannot be played directly. Use ParticleEngine#playLooping(LoopingEffect, TaskSchedule,"
+            "Looping effects cannot be played directly. Use ParticleEngine#playLooping(LoopingEffect, int,"
                 + " PacketGroupingAudience) instead.");
     }
 
-    public abstract void playNextTick(PacketGroupingAudience audience);
+    public abstract void playNextTick(ParticleAudience audience, ParticleEngine ignored);
 }

--- a/src/main/java/net/cytonic/cytosis/particles/util/ParticleData.java
+++ b/src/main/java/net/cytonic/cytosis/particles/util/ParticleData.java
@@ -2,14 +2,29 @@ package net.cytonic.cytosis.particles.util;
 
 import java.util.Objects;
 
+import lombok.AccessLevel;
+import lombok.Getter;
 import net.kyori.adventure.text.format.TextColor;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Pos;
+import net.minestom.server.network.NetworkBuffer;
+import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.network.packet.server.play.ParticlePacket;
 import net.minestom.server.particle.Particle;
 import org.jetbrains.annotations.NotNull;
 
+@Getter(AccessLevel.PRIVATE)
 public class ParticleData {
+
+    public static final NetworkBuffer.Type<ParticleData> NETWORK_TYPE = NetworkBufferTemplate.template(
+        Particle.NETWORK_TYPE, ParticleData::getParticle,
+        NetworkBuffer.BOOLEAN, ParticleData::isOverrideLimiter,
+        NetworkBuffer.BOOLEAN, ParticleData::isLongDistance,
+        NetworkBuffer.POS.transform(pos -> pos, Point::asPos), ParticleData::getOffset,
+        NetworkBuffer.FLOAT, ParticleData::getMaxSpeed,
+        NetworkBuffer.VAR_INT, ParticleData::getParticleCount,
+        ParticleData::new
+    );
 
     Particle particle;
     boolean overrideLimiter;
@@ -26,6 +41,11 @@ public class ParticleData {
         this.offset = offset;
         this.maxSpeed = maxSpeed;
         this.particleCount = particleCount;
+    }
+
+    public static ParticleData fromPacket(ParticlePacket p) {
+        return new ParticleData(p.particle(), p.overrideLimiter(), p.longDistance(),
+            new Pos(p.offsetX(), p.offsetY(), p.offsetZ()), p.maxSpeed(), p.particleCount());
     }
 
     public static ParticleData simple(Particle p) {

--- a/src/main/java/net/cytonic/cytosis/world/AbstractWorld.java
+++ b/src/main/java/net/cytonic/cytosis/world/AbstractWorld.java
@@ -2,15 +2,27 @@ package net.cytonic.cytosis.world;
 
 import java.util.UUID;
 
+import lombok.Getter;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.instance.InstanceContainer;
 import net.minestom.server.registry.RegistryKey;
 import net.minestom.server.world.DimensionType;
 
+import net.cytonic.cytosis.particles.ParticleEngine;
+
+@Getter
 public abstract class AbstractWorld extends InstanceContainer {
+
+    private final ParticleEngine particleEngine;
 
     public AbstractWorld(UUID uuid, RegistryKey<DimensionType> dimensionType) {
         super(uuid, dimensionType);
+
+        // make particle engine accessible via a tag or method
+        this.particleEngine = new ParticleEngine(this);
+        setTag(ParticleEngine.TAG, particleEngine);
+
         MinecraftServer.getInstanceManager().registerInstance(this);
     }
+
 }


### PR DESCRIPTION
This is breaking because it takes the particle engine from being a statically accessed utility class to be per instance. It can be accessed via the `ParticleEngine.TAG` tag, or via `AbstractWorld#getParticleEngine`. Also tweaked the debug commands to use the instance particle engine.